### PR TITLE
Fixed docker build script

### DIFF
--- a/docker/build_docker_image.sh
+++ b/docker/build_docker_image.sh
@@ -20,7 +20,6 @@ fi
 
 BASEDIR=$(dirname "$0")
 docker build -f ${BASEDIR}/${dockerfile} -t gst-video-analytics:$tag \
-    --build-arg http_proxy=${HTTP_PROXY} \
-    --build-arg https_proxy=${HTTPS_PROXY} \
-    --build-arg dldt=${dldt} \
+    --build-arg http_proxy=${HTTP_PROXY:-$http_proxy} \
+    --build-arg https_proxy=${HTTPS_PROXY:-$https_proxy} \
     ${BASEDIR}/..


### PR DESCRIPTION
Changes the build_docker_image.sh to make it more generalize. Usually `http_proxy` used instead of `HTTP_PROXY`, I had changed the script to accept both. 
Had build issue with `--build-arg dldt=${dldt}`, after removing works fine. These changes are verified and tested, please consider them. Thanks