### PR TITLE
Fixed OpenCV install issue in Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -656,7 +656,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-
     libva-dev libxrandr-dev libudev-dev \
     \
     && rm -rf /var/lib/apt/lists/* \
-    && python3.6 -m pip install numpy opencv-python pytest
+    && python3.6 -m pip install --upgrade pip && python3.6 -m pip install numpy opencv-python pytest
 
 # Install
 COPY --from=dldt-build /home/build /

--- a/docker/binaries.Dockerfile
+++ b/docker/binaries.Dockerfile
@@ -622,7 +622,7 @@ RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-
     libva-dev libxrandr-dev libudev-dev \
     \
     && rm -rf /var/lib/apt/lists/* \
-    && python3.6 -m pip install numpy opencv-python pytest
+    && python3.6 -m pip install --upgrade pip && python3.6 -m pip install numpy opencv-python pytest
 
 # Install
 COPY --from=dldt-build /home/build /


### PR DESCRIPTION
Added a prerequisite step to upgrade pip before installing opencv-python.
This is the error while building container **without** the fix:

```
Collecting opencv-python
  Downloading https://files.pythonhosted.org/packages/77/f5/49f034f8d109efcf9b7e98fbc051878b83b2f02a1c73f92bbd37f317288e/opencv-python-4.4.0.42.tar.gz (88.9MB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-n761d8ed/opencv-python/setup.py", line 9, in <module>
        import skbuild
    ModuleNotFoundError: No module named 'skbuild'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-n761d8ed/opencv-python/
The command '/bin/sh -c apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y -q --no-install-recommends     libusb-1.0-0-dev libboost-all-dev libgtk2.0-dev python-yaml         clinfo libboost-all-dev libjson-c-dev     build-essential cmake ocl-icd-opencl-dev wget gcovr vim git gdb ca-certificates libssl-dev uuid-dev     libgirepository1.0-dev     python3-dev python3-wheel python3-pip python3-setuptools python-gi-dev python-yaml         libglib2.0-dev libgmp-dev libgsl-dev gobject-introspection libcap-dev libcap2-bin gettext         libx11-dev iso-codes libegl1-mesa-dev libgles2-mesa-dev libgl-dev gudev-1.0 libtheora-dev libcdparanoia-dev libpango1.0-dev libgbm-dev libasound2-dev libjpeg-dev     libvisual-0.4-dev libxv-dev libopus-dev libgraphene-1.0-dev libvorbis-dev         libbz2-dev libv4l-dev libaa1-dev libflac-dev libgdk-pixbuf2.0-dev libmp3lame-dev libcaca-dev libdv4-dev libmpg123-dev libraw1394-dev libavc1394-dev libiec61883-dev     libpulse-dev libsoup2.4-dev libspeex-dev libtag-extras-dev libtwolame-dev libwavpack-dev         libbluetooth-dev libusb-1.0.0-dev libass-dev libbs2b-dev libchromaprint-dev liblcms2-dev libssh2-1-dev libdc1394-22-dev libdirectfb-dev libssh-dev libdca-dev     libfaac-dev libfdk-aac-dev flite1-dev libfluidsynth-dev libgme-dev libgsm1-dev nettle-dev libkate-dev liblrdf0-dev libde265-dev libmjpegtools-dev libmms-dev     libmodplug-dev libmpcdec-dev libneon27-dev libopenal-dev libopenexr-dev libopenjp2-7-dev libopenmpt-dev libopenni2-dev libdvdnav-dev librtmp-dev librsvg2-dev     libsbc-dev libsndfile1-dev libsoundtouch-dev libspandsp-dev libsrtp2-dev libzvbi-dev libvo-aacenc-dev libvo-amrwbenc-dev libwebrtc-audio-processing-dev libwebp-dev     libwildmidi-dev libzbar-dev libnice-dev libxkbcommon-dev         libmpeg2-4-dev libopencore-amrnb-dev libopencore-amrwb-dev liba52-0.7.4-dev         libva-dev libxrandr-dev libudev-dev         && rm -rf /var/lib/apt/lists/*     && python3.6 -m pip install numpy opencv-python pytest' returned a non-zero code: 1
```