### PR TITLE
Fix libva path setup in setup_dls_env.ps1

### DIFF
--- a/scripts/setup_dls_env.ps1
+++ b/scripts/setup_dls_env.ps1
@@ -1,6 +1,6 @@
 #Requires -RunAsAdministrator
 # ==============================================================================
-# Copyright (C) 2025 Intel Corporation
+# Copyright (C) 2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 # ==============================================================================
@@ -256,4 +256,3 @@ try {
 }
 
 Write-Host "DLStreamer is ready"
-


### PR DESCRIPTION
There is no exact match `VideoAccelerationCompatibilityPack` in `$pathEntries`, so a new entry is added to PATH when ever the script is excuted.