### PR TITLE
Fix DLL output paths on Windows

### DIFF
--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -68,7 +68,7 @@ jobs:
       shell: powershell
       run: |
         $target = "${{ env.DLS_TARGET_DIRECTORY }}"
-        $source = "C:\dlstreamer_tmp\build\intel64\Release\bin\Release"
+        $source = "C:\dlstreamer_tmp\build\intel64\Release\bin"
         Write-Host "`nContents of source directory ($source):"
         Get-ChildItem -Path $source -Recurse
         if (Test-Path $target) {

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ==============================================================================
-# Copyright (C) 2018-2025 Intel Corporation
+# Copyright (C) 2018-2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 # ==============================================================================
@@ -76,11 +76,21 @@ if (NOT(BIN_FOLDER))
     endif()
 endif()
 
-set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/lib)
-set (CMAKE_PLUGIN_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/lib/gstreamer-1.0)
-set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/lib)
-set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/bin)
-set (CMAKE_SAMPLES_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/samples)
+# Use generator expression for build type
+set (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/$<CONFIG>/lib)
+set (CMAKE_PLUGIN_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/$<CONFIG>/lib/gstreamer-1.0)
+set (CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/$<CONFIG>/lib)
+set (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/$<CONFIG>/bin)
+set (CMAKE_SAMPLES_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/$<CONFIG>/samples)
+
+# For multi-config generators (Visual Studio), set per-configuration output directories to prevent appending an additional config subdirectory.
+# For single-config generators (Makefiles), CMAKE_CONFIGURATION_TYPES is empty, so this loop is skipped.
+foreach(OUTPUTCONFIG ${CMAKE_CONFIGURATION_TYPES})
+    string(TOUPPER ${OUTPUTCONFIG} OUTPUTCONFIG_UPPER)
+    set(CMAKE_LIBRARY_OUTPUT_DIRECTORY_${OUTPUTCONFIG_UPPER} ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${OUTPUTCONFIG}/lib)
+    set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY_${OUTPUTCONFIG_UPPER} ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${OUTPUTCONFIG}/lib)
+    set(CMAKE_RUNTIME_OUTPUT_DIRECTORY_${OUTPUTCONFIG_UPPER} ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${OUTPUTCONFIG}/bin)
+endforeach()
 
 set (DLSTREAMER_LIBRARIES_INSTALL_PATH lib)
 set (DLSTREAMER_PLUGINS_INSTALL_PATH ${DLSTREAMER_LIBRARIES_INSTALL_PATH}/gstreamer-1.0)

--- a/include/dlstreamer/gst/videoanalytics/CMakeLists.txt
+++ b/include/dlstreamer/gst/videoanalytics/CMakeLists.txt
@@ -1,5 +1,5 @@
 # ==============================================================================
-# Copyright (C) 2018-2024 Intel Corporation
+# Copyright (C) 2018-2026 Intel Corporation
 #
 # SPDX-License-Identifier: MIT
 # ==============================================================================
@@ -52,6 +52,5 @@ if(${ENABLE_AUDIO_INFERENCE_ELEMENTS})
         target_link_libraries(${TARGET_NAME} INTERFACE ${GSTAUDIO_LIBRARIES})
 endif()
 
-configure_file(${CMAKE_SOURCE_DIR}/cmake/dl-streamer.pc.in ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pkgconfig/dl-streamer.pc @ONLY)
-
-install(FILES ${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/pkgconfig/dl-streamer.pc DESTINATION ${DLSTREAMER_LIBRARIES_INSTALL_PATH}/pkgconfig/)
+configure_file(${CMAKE_SOURCE_DIR}/cmake/dl-streamer.pc.in ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/lib/pkgconfig/dl-streamer.pc @ONLY)
+install(FILES ${CMAKE_BINARY_DIR}/${BIN_FOLDER}/${CMAKE_BUILD_TYPE}/lib/pkgconfig/dl-streamer.pc DESTINATION ${DLSTREAMER_LIBRARIES_INSTALL_PATH}/pkgconfig/)


### PR DESCRIPTION
Currently there can be 4 folders for Release/Debug dll output on Windows, which is very confusing. 
```
build\intel64\Release\bin\Release
build\intel64\Release\bin\Debug
build\intel64\Debug\bin\Debug
build\intel64\Debug\bin\Release
```

This PR removes the last build type and aligns to Linux paths. The result is
```
build\intel64\Release\bin
build\intel64\Debug\bin
```

Also updated `configure_file` command's paths because it does not support generator expressions.