### PR TITLE
Update vcpkg opencv config

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -1,6 +1,10 @@
 {
     "dependencies": [
-        "opencv",
+        {
+            "name": "opencv4",
+            "default-features": false,
+            "features": ["world", "opencl", "calib3d", "dshow", "fs", "intrinsics", "msmf", "thread", "win32ui"]
+        },
         "pkgconf",
         "opencl",
         "dlfcn-win32",


### PR DESCRIPTION
Merge all opencv modules into `opencv_world4.dll`.
Also enables `opencl` support in opencv.

Before:
```
-a----        03/12/2025     06:31        2432512 opencv_calib3d4.dll                                                  
-a----        03/12/2025     06:23        3013632 opencv_core4.dll                                                     
-a----        03/12/2025     06:31        4442624 opencv_dnn4.dll                                                      
-a----        03/12/2025     06:26         732672 opencv_features2d4.dll                                               
-a----        03/12/2025     06:23         427008 opencv_flann4.dll                                                    
-a----        03/12/2025     06:25        4549120 opencv_imgproc4.dll                                                  
-a----        03/12/2025     06:32        1178112 opencv_objdetect4.dll     
```
After:
```
-a----        16/12/2025     14:36       15077888 opencv_world4.dll
```