### PR TITLE
DOCS codeowners fix for docs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,12 +3,13 @@ CONTRIBUTING.md     @pmalatyn
 CODE_OF_CONDUCT.md  @pmalatyn
 SECURITY.md         @pmalatyn
 README.md           @tbujewsk @open-edge-platform/open-edge-platform-docs-write
+
 ## dlstreamer worfklows ##
 /.github/workflows/* @tbujewsk @nszczygl9 @dmichalo @yangjianfeng1208
 ## dlstreamer repo ##
 * @tbujewsk @OskarFiedot @marcin-wadolkowski @nszczygl9 @dmichalo @msmiatac @jmotow @pbartosik @mholowni @qianlongding @BaoHuiling @yunowo @ZiningLi @yangjianfeng1208 @oonyshch @walidbarakat
-
 ## Documentation files ##
-/docs/* @tbujewsk @OskarFiedot @marcin-wadolkowski @nszczygl9 @dmichalo @msmiatac @jmotow @pbartosik @mholowni @qianlongding @BaoHuiling @yunowo @ZiningLi @yangjianfeng1208 @oonyshch @walidbarakat @open-edge-platform/open-edge-platform-docs-write
+/docs/ @tbujewsk @OskarFiedot @marcin-wadolkowski @nszczygl9 @dmichalo @msmiatac @jmotow @pbartosik @mholowni @qianlongding @BaoHuiling @yunowo @ZiningLi @yangjianfeng1208 @oonyshch @walidbarakat @open-edge-platform/open-edge-platform-docs-write
+
 
 


### PR DESCRIPTION
### Description
Removing wildcard, it seems to be limiting the ownership to the same folder

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

