### PR TITLE
[DOCS] elements.md toctree fix - gvafpsthrottle

### DIFF
--- a/docs/source/elements/elements.md
+++ b/docs/source/elements/elements.md
@@ -46,6 +46,7 @@ gvaaudiotranscribe
 gvagenai
 gvaattachroi
 gvafpscounter
+gvafpsthrottle
 gvametaaggregate
 gvametaconvert
 gvametapublish


### PR DESCRIPTION
Quick fix for missing gvafpsthrottle added to toctree in elements.md.