### PR TITLE
Improve dependency management in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,15 @@ install: build ## Build and install Deep Learning Streamer
 	@echo "Installing Deep Learning Streamer"
 	@mkdir -p ${DLSTREAMER_INSTALL_PREFIX}
 	@rm -rf ${DLSTREAMER_INSTALL_PREFIX}/*
+	@if [ -f build/deps/.deps_built ]; then \
+		echo "Installing dependencies..."; \
+		cmake \
+			-B build/deps \
+			-DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+			-DINSTALL_DLSTREAMER=True \
+			-DDLSTREAMER_INSTALL_PREFIX=${DLSTREAMER_INSTALL_PREFIX} \
+			./dependencies; \
+	fi
 	@cp -r build/intel64/${BUILD_TYPE} ${DLSTREAMER_INSTALL_PREFIX}
 	@cp -r samples/ ${DLSTREAMER_INSTALL_PREFIX}
 	@cp -r python/ ${DLSTREAMER_INSTALL_PREFIX}


### PR DESCRIPTION
### Description

Currently if code changes, redo 'make build' or 'make install' will cause core dump since the dependencies are already built.
Check to dependencies status to decide whether to build dependencies

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

