### PR TITLE
Fix directory already exists error

### DIFF
--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Copy DL Streamer repo
         shell: powershell
         run: |
-          $target = "${{ env.DLS_TARGET_DIRECTORY }}"
+          $target = "${{ env.DLS_REPO_TARGET_DIRECTORY }}"
           if (Test-Path $target) {
               Remove-Item -Recurse -Force $target
           }


### PR DESCRIPTION
### Description

Fix the error
```
Run $target = "C:\dlstreamer"
New-Item : An item with the specified name C:\dlstreamer_repo already exists.
At C:\actions-runner\_work\_temp\39311cbc-ecd7-4301-9265-b8e9c29fcdbd.ps1:6 char:1
+ New-Item -ItemType Directory -Path C:\dlstreamer_repo | Out-Null
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ResourceExists: (C:\dlstreamer_repo:String) [New-Item], IOException
    + FullyQualifiedErrorId : DirectoryExist,Microsoft.PowerShell.Commands.NewItemCommand
```

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

