### PR TITLE
Update Windows model/video paths in workflow

### DIFF
--- a/.github/workflows/dls-build-and-test-windows.yaml
+++ b/.github/workflows/dls-build-and-test-windows.yaml
@@ -24,8 +24,8 @@ env:
   GSTREAMER_DIRECTORY: 'C:\gstreamer'
   BUILD_TOOLS_DIRECTORY: 'C:\BuildTools'
   VCPKG_DIRECTORY: 'C:\vcpkg'
-  MODELS_PATH: 'C:\models'
-  VIDEO_INPUTS_PATH: 'C:\videos'
+  MODELS_PATH: 'C:\models\models'
+  VIDEO_INPUTS_PATH: 'C:\videos\videos'
   TESTS_RESULTS_DIRECTORY: 'C:\dlstreamer_test_results'
   PYTHON_VERSION: '3.12.7'
 


### PR DESCRIPTION
Update Windows CI environment variables to use nested directories for models and videos. MODELS_PATH and VIDEO_INPUTS_PATH are changed to 'C:\\models\\models' and 'C:\\videos\\videos' so the workflow matches the repository's test input layout and the CI can locate model and video files correctly.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

