### PR TITLE
Autodetect boxes and masks output tensors in yolo-seg models.

### DIFF
--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v26.cpp
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v26.cpp
@@ -234,12 +234,12 @@ TensorsTable YOLOv26SegConverter::convert(const OutputBlobs &output_blobs) {
             const InferenceBackend::OutputBlob::Ptr blob = blob_iter.second;
             std::vector<size_t> dims = blob->GetDims();
             // mask blob has shape: [batch, mask_count, height/4, width/4]
-            if ((dims.size() == 4) && (dims[2] == getModelInputImageInfo().height / 4) &&
+            if ((dims.size() == 4) && (dims[0] == batch_size) && (dims[2] == getModelInputImageInfo().height / 4) &&
                 (dims[3] == getModelInputImageInfo().width / 4)) {
                 masks_blob = InferenceBackend::OutputBlob::Ptr(blob);
             }
             // boxes blob has shape: [batch, num_boxes, 6 + mask_count] where default mask_count=32
-            if ((dims.size() == 3) && (dims[2] == YOLOV26_OFFSET_L + 1 + 32)) {
+            if ((dims.size() == 3) && (dims[0] == batch_size)) {
                 boxes_blob = InferenceBackend::OutputBlob::Ptr(blob);
             }
         }

--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v8.h
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v8.h
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (C) 2024-2025 Intel Corporation
+ * Copyright (C) 2024-2026 Intel Corporation
  *
  * SPDX-License-Identifier: MIT
  ******************************************************************************/
@@ -35,9 +35,6 @@ const int YOLOV8_OFFSET_Y = 1;  // y coordinate of bounding box center
 const int YOLOV8_OFFSET_W = 2;  // width of bounding box center
 const int YOLOV8_OFFSET_H = 3;  // height of bounding box center
 const int YOLOV8_OFFSET_CS = 4; // class probability
-
-const std::string TENSORS_BOXES_KEY = "boxes";
-const std::string TENSORS_MASKS_KEY = "masks";
 
 class YOLOv8Converter : public BlobToROIConverter {
   protected:


### PR DESCRIPTION
### Description

Auto-detect boxes/masks tensor so there is no need to apply tensor names during model conversion. 

Execution: https://github.com/open-edge-platform/dlstreamer/actions/runs/21755042624 

Fixes # (issue)

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

Tested locally with yolo-seg models. 

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

