### PR TITLE
latency tracker fix for smart intersection pipelines

### DIFF
--- a/src/gst/tracers/latency_tracer/latency_tracer.cpp
+++ b/src/gst/tracers/latency_tracer/latency_tracer.cpp
@@ -759,7 +759,7 @@ static void do_push_buffer_pre(LatencyTracer *lt, guint64 ts, GstPad *pad, GstBu
             add_latency_meta(lt, meta, ts, buffer, elem);
             meta = LATENCY_TRACER_META_GET(buffer);
             if (!meta)
-                return;  // Buffer wasn't writable, skip
+                return; // Buffer wasn't writable, skip
         }
         // Don't return early - continue to check for sink peer
         if (!meta)


### PR DESCRIPTION

### Description

The tracer needs to re-stamp metadata on buffers that lost it when they're about to reach a sink element. The current optimization of only adding metadata at source elements breaks the tracer for any pipeline containing elements that create new buffers (decoders, encoders, converters, etc.). The fix: Re-add metadata for buffers missing it at non-source elements. In do_push_buffer_pre, instead of immediately returning when meta is NULL and the element is not a source, also add metadata when the element's peer is a sink (or more broadly, whenever metadata is missing on a writable buffer)

Fixes # (issue): Fix latency_tracker for pipelines in smart intersection: multifilesrc loop=true ! decodebin3 ! appsink

### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

Unit tested.

### Checklist:

- [X] I agree to use the MIT license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with MIT. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.

