### PR TITLE
[GST gvawatermark] fix documentation description for text background

### DIFF
--- a/docs/source/elements/gvawatermark.md
+++ b/docs/source/elements/gvawatermark.md
@@ -123,7 +123,7 @@ Controls the size of text labels displayed on detected objects.
 **Text Background Enabled (`draw-txt-bg=true`)**
 ![Text Background](../_images/show-text-background.png)
 
-*White background makes text more readable over complex backgrounds*
+*Blue background makes text more readable over complex backgrounds*
 
 ### Color Index
 


### PR DESCRIPTION
### Description

gvawatermark option "draw-txt-bg=true" render the label background to be blue.

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

