### PR TITLE
[GST gvawatermark] update display configuration defaults

### DIFF
--- a/docs/source/elements/gvawatermark.md
+++ b/docs/source/elements/gvawatermark.md
@@ -69,10 +69,10 @@ Element Properties:
   displ-cfg           : Comma separated list of KEY=VALUE parameters of displayed notations.
                         Available options:
                         show-labels=<bool> enable or disable displaying text labels, default true
-                        font-scale=<double 0.1 to 2.0> scale factor for text labels, default 1.0
+                        font-scale=<double 0.1 to 2.0> scale factor for text labels, default 0.5
                         thickness=<uint> bounding box thickness, default 2
                         color-idx=<int> color index for bounding box, keypoints, and text, default -1 (use default colors: 0 red, 1 green, 2 blue)
-                        draw-txt-bg=<bool> enable or disable displaying text labels background, by enabling it the text color is set to white, default false
+                        draw-txt-bg=<bool> enable or disable displaying text labels background, by enabling it the text color is set to white, default true
                         font-type=<string> font type for text labels, default triplex. Supported fonts: simplex, plain, duplex, complex, triplex, complex_small, script_simplex, script_complex
                         e.g.: displ-cfg=show-labels=false
                         e.g.: displ-cfg=font-scale=0.5,thickness=3,color-idx=2,font-type=plain

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -60,7 +60,7 @@ GST_DEBUG_CATEGORY_STATIC(gst_gva_watermark_impl_debug_category);
 
 #define DEFAULT_DEVICE nullptr
 #define DEFAULT_THICKNESS (2)
-#define DEFAULT_TEXT_SCALE (1.0)
+#define DEFAULT_TEXT_SCALE (0.5)
 #define DEFAULT_COLOR_IDX (-1)
 
 // Font scale validation ranges
@@ -190,7 +190,7 @@ struct Impl {
 
     struct DisplCfg {
         bool show_labels = true;
-        bool draw_text_background = false;
+        bool draw_text_background = true;
         int color_idx = DEFAULT_COLOR_IDX;
         uint thickness = DEFAULT_THICKNESS;
         int font_type = cv::FONT_HERSHEY_TRIPLEX;

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
@@ -74,14 +74,14 @@ enum { PROP_0, PROP_DEVICE, PROP_OBB, PROP_DISPL_AVGFPS, PROP_DISPL_CFG };
     "Comma separated list of KEY=VALUE parameters of displayed notations.\n"                                           \
     "\t\t\tAvailable options: \n"                                                                                      \
     "\t\t\tshow-labels=<bool> enable or disable displaying text labels, default true\n"                                \
-    "\t\t\tfont-scale=<double 0.1 to 2.0> scale factor for text labels, default 1.0\n"                                 \
+    "\t\t\tfont-scale=<double 0.1 to 2.0> scale factor for text labels, default 0.5\n"                                 \
     "\t\t\tthickness=<uint 1 to 10> bounding box thickness, default 2\n"                                               \
     "\t\t\tcolor-idx=<int> color index for bounding box, keypoints, and text, default -1 (use default colors: 0 red, " \
     "1 green, 2 blue)\n"                                                                                               \
     "\t\t\tfont-type=<string> font type for text labels (simplex, plain, duplex, complex, triplex, complex_small, "    \
     "script_simplex, script_complex), default triplex\n"                                                               \
     "\t\t\tdraw-txt-bg=<bool> enable or disable displaying text labels background, by enabling it the text color "     \
-    "is set to white, default false\n"                                                                                 \
+    "is set to white, default true\n"                                                                                  \
     "\t\t\tshow-roi=<string> colon-separated list of labels to include (only these objects will be shown), "           \
     "default empty\n"                                                                                                  \
     "\t\t\thide-roi=<string> colon-separated list of labels to exclude (these objects will be hidden), default "       \


### PR DESCRIPTION
### Description

update display configuration defaults to have text background enabled by defaults and text scale to 0.5

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

