### PR TITLE
Enable custom code to add GstAnalytics data outside of DLS components

### DIFF
--- a/include/dlstreamer/gst/videoanalytics/video_frame.h
+++ b/include/dlstreamer/gst/videoanalytics/video_frame.h
@@ -357,20 +357,29 @@ class VideoFrame {
             gst_analytics_relation_meta_iterate(relation_meta, &state, gst_analytics_od_mtd_get_mtd_type(), &od_mtd)) {
             GstVideoRegionOfInterestMeta *roi_meta = gst_buffer_get_video_region_of_interest_meta_id(buffer, od_mtd.id);
 
-            // GstVideoRegionOfInterestMeta should match GstAnalytics until transition to GstAnalytics is complete
+            // GstVideoRegionOfInterestMeta should match GstAnalyticsODMtd until transition to GstAnalytics is complete
             // a mismatch can occur if external code adds GstAnalytics metadata only
             if (!roi_meta) {
                 if (!gst_buffer_is_writable(buffer))
                     throw std::runtime_error("GVA::VideoFrame: Failed to add video region of interest meta.");
-                float confidence;
+
+                // retrieve bounding-box data from GstAnalytics structure
+                gfloat confidence;
                 gint x, y, w, h;
-                gst_analytics_od_mtd_get_location(&od_mtd, &x, &y, &w, &h, &confidence);
                 GQuark label = gst_analytics_od_mtd_get_obj_type(&od_mtd);
+                gst_analytics_od_mtd_get_location(&od_mtd, &x, &y, &w, &h, &confidence);
+
+                // create GstVideoRegionOfInterestMeta to match GstAnalyticsODMtd
+                GstStructure *detection = gst_structure_new("detection", "x_min", G_TYPE_DOUBLE, double(x), "x_max",
+                                                            G_TYPE_DOUBLE, double(x + w), "y_min", G_TYPE_DOUBLE,
+                                                            double(y), "y_max", G_TYPE_DOUBLE, double(y + h), NULL);
+                gst_structure_set(detection, "confidence", G_TYPE_DOUBLE, double(confidence), NULL);
                 roi_meta = gst_buffer_add_video_region_of_interest_meta(buffer, g_quark_to_string(label), x, y, w, h);
                 if (!roi_meta)
                     throw std::runtime_error(
                         "GVA::VideoFrame: Failed to get video region of interest meta for object detection metadata");
                 roi_meta->id = od_mtd.id;
+                gst_video_region_of_interest_meta_add_param(roi_meta, detection);
             }
 
             regions.emplace_back(od_mtd, roi_meta);


### PR DESCRIPTION
### Description

DLStreamer components (metapublish, watermark) are not able to handle GstAnalytic metadata added by custom logic. 
This change removes this limitation. 

Fixes # (issue)

### Any Newly Introduced Dependencies

N/A> 

### How Has This Been Tested?

Validated locally and through CI system. 

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

