### PR TITLE
Windows - install VS Build Tools in setup script

### DIFF
--- a/scripts/setup_dls_env.ps1
+++ b/scripts/setup_dls_env.ps1
@@ -16,6 +16,16 @@ if (-Not (Test-Path $DLSTREAMER_TMP)) {
 	mkdir $DLSTREAMER_TMP
 }
 
+# Install Visual Studio Build Tools if not already installed
+if (-Not (Test-Path "C:\\BuildTools")) {
+	Write-Host "###################################### Installing VS BuildTools #######################################"
+	Invoke-WebRequest -OutFile $DLSTREAMER_TMP\\vs_buildtools.exe -Uri https://aka.ms/vs/17/release/vs_buildtools.exe
+	Start-Process -Wait -FilePath $DLSTREAMER_TMP\vs_buildtools.exe -ArgumentList "--quiet", "--wait", "--norestart", "--nocache", "--installPath", "C:\\BuildTools", "--add", "Microsoft.VisualStudio.Component.VC.Tools.x86.x64", "--add", "Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Core"
+	Write-Host "############################################### Done ##################################################"
+} else {
+	Write-Host "################################# VS BuildTools already installed #####################################"
+}
+
 # Check if GStreamer is installed and if it's the correct version
 $GSTREAMER_NEEDS_INSTALL = $false
 $GSTREAMER_INSTALL_MODE = "none"  # values: none | fresh | reinstall


### PR DESCRIPTION
### Description

Add installation step to scripts/setup_dls_env.ps1 that checks for C:\BuildTools and, if missing, downloads vs_buildtools.exe to $DLSTREAMER_TMP and runs it silently to install VC Tools (x86/x64) and Native Desktop Core components. Adds informational Write-Host output and skips installation when C:\BuildTools already exists.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

