### PR TITLE
Disable gstreamer gpl plugins

### DIFF
--- a/dependencies/gstreamer.cmake
+++ b/dependencies/gstreamer.cmake
@@ -54,7 +54,7 @@ ExternalProject_Add(
     	                -Dgst-plugins-good:flac=disabled
     	                -Dgst-plugins-good:dv=disabled
     	                -Dgst-plugins-good:soup=enabled
-    	                -Dgst-plugins-bad:gpl=enabled
+    	                -Dgst-plugins-bad:gpl=disabled
     	                -Dgst-plugins-bad:va=enabled
     	                -Dgst-plugins-bad:doc=disabled
     	                -Dgst-plugins-bad:nls=disabled
@@ -73,7 +73,7 @@ ExternalProject_Add(
     	                -Dgst-plugins-bad:libde265=enabled
     	                -Dgst-plugins-bad:openh264=enabled
     	                -Dgst-plugins-bad:uvch264=enabled
-    	                -Dgst-plugins-bad:x265=enabled
+    	                -Dgst-plugins-bad:x265=disabled
     	                -Dgst-plugins-bad:curl=enabled
     	                -Dgst-plugins-bad:curl-ssh2=enabled
     	                -Dgst-plugins-bad:opus=enabled
@@ -93,8 +93,8 @@ ExternalProject_Add(
     	                -Dgst-plugins-bad:isac=disabled
 		                -Dgst-plugins-bad:openexr=disabled
     	                -Dgst-plugins-ugly:nls=disabled
-    	                -Dgst-plugins-ugly:x264=enabled
-    	                -Dgst-plugins-ugly:gpl=enabled
+    	                -Dgst-plugins-ugly:x264=disabled
+    	                -Dgst-plugins-ugly:gpl=disabled
     	                -Dgstreamer-vaapi:encoders=enabled
     	                -Dgstreamer-vaapi:drm=enabled
     	                -Dgstreamer-vaapi:glx=enabled

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -228,7 +228,7 @@ RUN \
     -Dgst-plugins-good:flac=disabled \
     -Dgst-plugins-good:dv=disabled \
     -Dgst-plugins-good:soup=enabled \
-    -Dgst-plugins-bad:gpl=enabled \
+    -Dgst-plugins-bad:gpl=disabled \
     -Dgst-plugins-bad:va=enabled \
     -Dgst-plugins-bad:doc=disabled \
     -Dgst-plugins-bad:nls=disabled \
@@ -248,7 +248,7 @@ RUN \
     -Dgst-plugins-bad:libde265=enabled \
     -Dgst-plugins-bad:openh264=enabled \
     -Dgst-plugins-bad:uvch264=enabled \
-    -Dgst-plugins-bad:x265=enabled \
+    -Dgst-plugins-bad:x265=disabled \
     -Dgst-plugins-bad:curl=enabled \
     -Dgst-plugins-bad:curl-ssh2=enabled \
     -Dgst-plugins-bad:opus=enabled \
@@ -267,8 +267,8 @@ RUN \
     -Dgst-plugins-bad:soundtouch=disabled \
     -Dgst-plugins-bad:isac=disabled \
     -Dgst-plugins-ugly:nls=disabled \
-    -Dgst-plugins-ugly:x264=enabled \
-    -Dgst-plugins-ugly:gpl=enabled \
+    -Dgst-plugins-ugly:x264=disabled \
+    -Dgst-plugins-ugly:gpl=disabled \
     -Dgstreamer-vaapi:encoders=enabled \
     -Dgstreamer-vaapi:drm=enabled \
     -Dgstreamer-vaapi:glx=enabled \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -223,7 +223,7 @@ RUN \
     -Dgst-plugins-good:flac=disabled \
     -Dgst-plugins-good:dv=disabled \
     -Dgst-plugins-good:soup=enabled \
-    -Dgst-plugins-bad:gpl=enabled \
+    -Dgst-plugins-bad:gpl=disabled \
     -Dgst-plugins-bad:va=enabled \
     -Dgst-plugins-bad:doc=disabled \
     -Dgst-plugins-bad:nls=disabled \
@@ -243,7 +243,7 @@ RUN \
     -Dgst-plugins-bad:libde265=enabled \
     -Dgst-plugins-bad:openh264=enabled \
     -Dgst-plugins-bad:uvch264=enabled \
-    -Dgst-plugins-bad:x265=enabled \
+    -Dgst-plugins-bad:x265=disabled \
     -Dgst-plugins-bad:curl=enabled \
     -Dgst-plugins-bad:curl-ssh2=enabled \
     -Dgst-plugins-bad:opus=enabled \
@@ -262,8 +262,8 @@ RUN \
     -Dgst-plugins-bad:soundtouch=disabled \
     -Dgst-plugins-bad:isac=disabled \
     -Dgst-plugins-ugly:nls=disabled \
-    -Dgst-plugins-ugly:x264=enabled \
-    -Dgst-plugins-ugly:gpl=enabled \
+    -Dgst-plugins-ugly:x264=disabled \
+    -Dgst-plugins-ugly:gpl=disabled \
     -Dgstreamer-vaapi:encoders=enabled \
     -Dgstreamer-vaapi:drm=enabled \
     -Dgstreamer-vaapi:glx=enabled \

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -229,7 +229,7 @@ RUN \
     -Dgst-plugins-good:flac=disabled \
     -Dgst-plugins-good:dv=disabled \
     -Dgst-plugins-good:soup=enabled \
-    -Dgst-plugins-bad:gpl=enabled \
+    -Dgst-plugins-bad:gpl=disabled \
     -Dgst-plugins-bad:va=enabled \
     -Dgst-plugins-bad:doc=disabled \
     -Dgst-plugins-bad:nls=disabled \
@@ -249,7 +249,7 @@ RUN \
     -Dgst-plugins-bad:libde265=enabled \
     -Dgst-plugins-bad:openh264=enabled \
     -Dgst-plugins-bad:uvch264=enabled \
-    -Dgst-plugins-bad:x265=enabled \
+    -Dgst-plugins-bad:x265=disabled \
     -Dgst-plugins-bad:curl=enabled \
     -Dgst-plugins-bad:curl-ssh2=enabled \
     -Dgst-plugins-bad:opus=enabled \
@@ -268,8 +268,8 @@ RUN \
     -Dgst-plugins-bad:soundtouch=disabled \
     -Dgst-plugins-bad:isac=disabled \
     -Dgst-plugins-ugly:nls=disabled \
-    -Dgst-plugins-ugly:x264=enabled \
-    -Dgst-plugins-ugly:gpl=enabled \
+    -Dgst-plugins-ugly:x264=disabled \
+    -Dgst-plugins-ugly:gpl=disabled \
     -Dgstreamer-vaapi:encoders=enabled \
     -Dgstreamer-vaapi:drm=enabled \
     -Dgstreamer-vaapi:glx=enabled \


### PR DESCRIPTION
### Description

Disable gstreamer GPL plugins - x264 and x265

### Any Newly Introduced Dependencies
N/A
### How Has This Been Tested?



### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

