### PR TITLE
[POST-PROC][YOLOv26 OBB] add blob parsing function to handle obb dimension

### DIFF
--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v10.cpp
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/yolo_v10.cpp
@@ -21,42 +21,44 @@ using namespace post_processing;
 
 void YOLOv10Converter::parseOutputBlob(const float *data, const std::vector<size_t> &dims,
                                        std::vector<DetectedObject> &objects, bool oob) const {
+    const size_t num_classes = BlobToMetaConverter::getLabels().size();
+
+    if (num_classes == 0) [[unlikely]] {
+        throw std::invalid_argument("Num classes is zero.");
+    }
 
     size_t dims_size = dims.size();
-    size_t input_width = getModelInputImageInfo().width;
-    size_t input_height = getModelInputImageInfo().height;
+    const float *__restrict__ output_data = data;
+
+    const auto [input_width, input_height] =
+        std::make_pair(getModelInputImageInfo().width, getModelInputImageInfo().height);
+
+    const auto [object_size, max_proposal_count] = std::make_pair(dims[dims_size - 1], dims[dims_size - 2]);
+
+    const float inv_width = 1.0f / static_cast<float>(input_width);
+    const float inv_height = 1.0f / static_cast<float>(input_height);
 
     if (dims_size < BlobToROIConverter::min_dims_size)
         throw std::invalid_argument("Output blob dimensions size " + std::to_string(dims_size) +
                                     " is not supported (less than " +
                                     std::to_string(BlobToROIConverter::min_dims_size) + ").");
 
-    size_t object_size = dims[dims_size - 1];
-    size_t max_proposal_count = dims[dims_size - 2];
-    float *output_data = (float *)data;
-    const size_t num_classes = BlobToMetaConverter::getLabels().size();
-
-    if (num_classes == 0)
-        throw std::invalid_argument("Num classes is zero.");
-
     for (size_t box_index = 0; box_index < max_proposal_count; ++box_index) {
-
-        float box_score = output_data[YOLOV10_OFFSET_BS];
-        float labelId = output_data[YOLOV10_OFFSET_L];
-        size_t normLabelId = ((size_t)labelId) % num_classes;
+        const float box_score = output_data[YOLOV10_OFFSET_BS];
 
         if (box_score > confidence_threshold) {
+            const auto [X, Y, width, height, rotation, labelId] = std::make_tuple(
+                output_data[YOLOV10_OFFSET_X1], output_data[YOLOV10_OFFSET_Y1],
+                oob ? output_data[YOLOV10_OFFSET_X2] : output_data[YOLOV10_OFFSET_X2] - output_data[YOLOV10_OFFSET_X1],
+                oob ? output_data[YOLOV10_OFFSET_Y2] : output_data[YOLOV10_OFFSET_Y2] - output_data[YOLOV10_OFFSET_Y1],
+                oob ? output_data[YOLOV10_OFFSET_L + 1] : 0, output_data[YOLOV10_OFFSET_L]);
 
-            float x1 = output_data[YOLOV10_OFFSET_X1];
-            float y1 = output_data[YOLOV10_OFFSET_Y1];
-            float x2 = output_data[YOLOV10_OFFSET_X2] - x1;
-            float y2 = output_data[YOLOV10_OFFSET_Y2] - y1;
-            float r = oob ? output_data[YOLOV10_OFFSET_L + 1] : 0;
+            size_t normLabelId = ((size_t)labelId) % num_classes;
 
-            objects.push_back(DetectedObject(x1, y1, x2, y2, r, box_score, normLabelId,
-                                             BlobToMetaConverter::getLabelByLabelId(normLabelId), 1.0f / input_width,
-                                             1.0f / input_height, false));
+            objects.emplace_back(X, Y, width, height, rotation, box_score, normLabelId,
+                                 BlobToMetaConverter::getLabelByLabelId(normLabelId), inv_width, inv_height, oob);
         }
+
         output_data += object_size;
     }
 }


### PR DESCRIPTION
### Description

YOLOv26-OBB outputs center-based coordinates, YOLOv10 blob parsing function was interpreting these as corner-based coordinates.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

