### PR TITLE
[GST gvawatermark] fix watermark default text backgroung behaviour

### DIFF
--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -748,12 +748,12 @@ Impl::Impl(GstVideoInfo *info, InferenceBackend::MemoryType mem_type, GstElement
         find_gvafpscounter_element();
 
     // Parse display configuration
-    if (_displ_cfg) {
+    if (_displ_cfg)
         parse_displ_config();
-        if (_displCfg.draw_text_background) {
-            _renderer->enable_draw_txt_bg(true);
-            _renderer_opencv->enable_draw_txt_bg(true);
-        }
+
+    if (_displCfg.draw_text_background) {
+        _renderer->enable_draw_txt_bg(true);
+        _renderer_opencv->enable_draw_txt_bg(true);
     }
 }
 


### PR DESCRIPTION
### Description

in that commit d6b4de554147a9f297fb6bd8af7639d2ec5cee48 the default display configuration and the text background by default should be drawn. but if the user didn't specify `_displ_cfg` the text background is drawn, this commit to fix that bug.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

