### PR TITLE
[DOCS] Update openvino to 2026 along entire advanced install guide

### DIFF
--- a/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
+++ b/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
@@ -114,7 +114,7 @@ packages:
 
   In case of any problems with the installation scripts, [Follow OpenVINO™
   Toolkit instruction guide
-  here](https://docs.openvino.ai/2026/get-started/install-openvino/install-openvino-linux.html)
+  here](https://docs.openvino.ai/2026/get-started/install-openvino/install-openvino-archive-linux.html)
   to install OpenVINO™ on Linux.
 
   - Environment: **Runtime**


### PR DESCRIPTION
### Description

Updates the mismatch from openvino_2025 to openvino_2026 in install guide.

### Any Newly Introduced Dependencies

No new dependencies, just new working links.

### How Has This Been Tested?

Locally upon development.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.