### PR TITLE
[DOCS]: Typo fix in installation guide

### DIFF
--- a/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
+++ b/docs/source/dev_guide/advanced_install/advanced_install_guide_compilation.md
@@ -262,7 +262,7 @@ Set up the required environment variables:
 <!--hide_directive:::
 ::::hide_directive-->
 
-> **NOTE:**  For a permament solution, open `\~/.bashrc` and add the variables above
+> **NOTE:**  For a permanent solution, open `\~/.bashrc` and add the variables above
 > to set up Linux to use them for every terminal session.
 
 ## Step 10: Install Python dependencies (optional)


### PR DESCRIPTION
### Description

A very small typo in install guide fix.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.