### PR TITLE
Use OpenCV pre-processor to compress non-continuous tensors (yielding best performance).

### DIFF
--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -647,15 +647,6 @@ class OpenVinoNewApiImpl {
             tensor = ov::Tensor(tensor, begin, end);
         }
 
-        // Allocate new tensor in host memory and COPY data if the original tensor is not contigous
-        // - NPU device plugin requires contigous tensors (explicit assert)
-        // - GPU plugin fails in certain cases with non-contigous tensors
-        if (!tensor.is_continuous()) {
-            ov::Tensor sparse_tensor(tensor);
-            tensor = ov::Tensor(ov::element::u8, sparse_tensor.get_shape());
-            sparse_tensor.copy_to(tensor);
-        }
-
         return tensor;
     }
 
@@ -1376,8 +1367,9 @@ bool OpenVINOImageInference::DoNeedImagePreProcessing(const InferenceBackend::Im
     if (image == nullptr)
         return false;
 
-    // workaround for NPU plugin serialization when non-contiguous tensors submitted
-    if ((_impl->_device.find("NPU") != std::string::npos) && (_impl->_memory_type == MemoryType::SYSTEM) &&
+    // OV plugins exhibit low peformance (serialization) when VA pre-processor generates non-continous tensors
+    // Add OpenCV pre-rocessor to compress non-continous tensors on top of VA pre-processor which does resize/crop/etc.
+    if ((_impl->_memory_type == MemoryType::SYSTEM) &&
         ((image->format == FourCC::FOURCC_RGBP) || (image->format == FourCC::FOURCC_BGRP))) {
 
         bool contiguous = (image->planes[1] - image->planes[0] == image->width * image->height) &&


### PR DESCRIPTION
### Description

If VA pre-processor generates sparse tensor (non-continuous memory), compress this tensor using OpenCV pre-processor. 
This configuration yields best performance across all platforms, and involves VA pre-processor for image operations (resize, crop, etc.) followed by OpenCV library used just to pack resulting tensor into a continuous memory space. 

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Performance validated manually across Intel Core Ultra devices + CI runs for regression. 

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

