### PR TITLE
Fix yamlint warning and readme dismatch

### DIFF
--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -418,7 +418,7 @@ jobs:
               Get-ChildItem -Path $base -Recurse -Depth 1 | ForEach-Object {
                   $item = $_
                   $totalSize = 0
-                  
+
                   if ($item.PSIsContainer) {
                       $stats = Get-ChildItem $item.FullName -Recurse -File -ErrorAction SilentlyContinue | Measure-Object -Property Length -Sum
                       $totalSize = $stats.Sum / 1MB

--- a/samples/windows/gstreamer/gst_launch/motion_detect/README.md
+++ b/samples/windows/gstreamer/gst_launch/motion_detect/README.md
@@ -1,6 +1,6 @@
 # Motion Detect Sample (gst-launch command line)
 
-This README documents the Windows `gvamotiondetect_demo.bat` script, a simple way to run the `gvamotiondetect` element in a GStreamer pipeline, additionally chaining `gvadetect` over motion ROIs.
+This README documents the Windows `motion_detect.bat` script, a simple way to run the `gvamotiondetect` element in a GStreamer pipeline, additionally chaining `gvadetect` over motion ROIs.
 
 ## How It Works
 
@@ -45,7 +45,7 @@ The sample uses YOLOv8n (resolved via `MODELS_PATH`) or other supported object d
 The batch script uses positional arguments (not `--param` flags).
 
 ```bat
-gvamotiondetect_demo.bat [DEVICE] [SOURCE] [MODEL] [PRECISION] [BACKEND] [OUTPUT] [MD_OPTS]
+motion_detect.bat [DEVICE] [SOURCE] [MODEL] [PRECISION] [BACKEND] [OUTPUT] [MD_OPTS]
 ```
 
 - `DEVICE`: Currently only support `CPU`. Default: `CPU`.
@@ -64,16 +64,16 @@ Notes:
 - CPU path with default source and model:
 ```bat
 set MODELS_PATH=C:\models
-gvamotiondetect_demo.bat CPU . . FP32 opencv display
+motion_detect.bat CPU . . FP32 opencv display
 ```
 - CPU path with local file, display output, and custom motion detector options:
 ```bat
 set MODELS_PATH=C:\models
-gvamotiondetect_demo.bat CPU C:\path\to\video.mp4 . FP32 opencv display "motion-threshold=0.07 min-persistence=2"
+motion_detect.bat CPU C:\path\to\video.mp4 . FP32 opencv display "motion-threshold=0.07 min-persistence=2"
 ```
 - Explicit model path:
 ```bat
-gvamotiondetect_demo.bat CPU C:\path\to\video.mp4 C:\path\to\models\yolov8n.xml FP32 opencv json
+motion_detect.bat CPU C:\path\to\video.mp4 C:\path\to\models\yolov8n.xml FP32 opencv json
 ```
 
 ## Motion Detector Options (`--md-opts`)


### PR DESCRIPTION
### Description
1. fix yamlint warning on dls-download-models.yaml
2. fix the readme script name dismatch for motiondetect

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

