### PR TITLE
Bump Ubuntu to 24.04.4 and kernel 6.17

### DIFF
--- a/docs/user-guide/get_started/system_requirements.md
+++ b/docs/user-guide/get_started/system_requirements.md
@@ -7,21 +7,21 @@ all available processing units:
 
  Codename | CPU | GPU | NPU | Operating system
 ----------|-----|-----|-----|----------------
- [Tiger Lake](https://www.intel.com/content/www/us/en/products/platforms/details/tiger-lake-h.html) | 11th generation of Intel® Core™ processors | Integrated Intel® Iris® Xe graphics | N/A | Ubuntu 22.04.5 LTS with kernel version 6.8.0-85<br>Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
- [Meteor Lake](https://www.intel.com/content/www/us/en/ark/products/codename/90353/products-formerly-meteor-lake.html) | Intel® Core™ Ultra Processors - series 1 | Integrated Intel® Arc™ A-Series Graphics | Integrated Intel® AI Boost | Ubuntu 22.04.5 LTS with kernel version 6.8.0-85<br>Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
- [Lunar Lake](https://www.intel.com/content/www/us/en/ark/products/codename/213792/products-formerly-lunar-lake.html) | Intel® Core™ Ultra Processors - series 2 | Integrated Intel® Arc™ B-Series Graphics | Integrated Intel® AI Boost | Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
- [Arrow Lake](https://www.intel.com/content/www/us/en/ark/products/codename/225837/products-formerly-arrow-lake.html) | Intel® Core™ Ultra Processors - series 2 | Integrated Intel® Arc™ Graphics | Integrated Intel® AI Boost | Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
+ [Tiger Lake](https://www.intel.com/content/www/us/en/products/platforms/details/tiger-lake-h.html) | 11th generation of Intel® Core™ processors | Integrated Intel® Iris® Xe graphics | N/A | Ubuntu 22.04.5 LTS with kernel version 6.8.0<br>Ubuntu 24.04.4 LTS with kernel version 6.17.0
+ [Meteor Lake](https://www.intel.com/content/www/us/en/ark/products/codename/90353/products-formerly-meteor-lake.html) | Intel® Core™ Ultra Processors - series 1 | Integrated Intel® Arc™ A-Series Graphics | Integrated Intel® AI Boost | Ubuntu 22.04.5 LTS with kernel version 6.8.0<br>Ubuntu 24.04.4 LTS with kernel version 6.17.0
+ [Lunar Lake](https://www.intel.com/content/www/us/en/ark/products/codename/213792/products-formerly-lunar-lake.html) | Intel® Core™ Ultra Processors - series 2 | Integrated Intel® Arc™ B-Series Graphics | Integrated Intel® AI Boost | Ubuntu 24.04.4 LTS with kernel version 6.17.0
+ [Arrow Lake](https://www.intel.com/content/www/us/en/ark/products/codename/225837/products-formerly-arrow-lake.html) | Intel® Core™ Ultra Processors - series 2 | Integrated Intel® Arc™ Graphics | Integrated Intel® AI Boost | Ubuntu 24.04.4 LTS with kernel version 6.17.0
  [Arrow Lake](https://www.intel.com/content/www/us/en/ark/products/codename/225837/products-formerly-arrow-lake.html) | Intel® Core™ Ultra Processors - series 2 | Integrated Intel® Arc™ Graphics Cards with GPU driver version 32.0.101.8425 | Integrated Intel® AI Boost with NPU driver version 32.0.100.4512 | Windows 11 Pro version 25H2
- [Panther Lake](https://www.intel.com/content/www/us/en/ark/products/codename/237132/products-formerly-panther-lake.html) | Intel® Core™ Ultra Processors - series 3 | Integrated Intel® Arc™ B390 GPU | Integrated Intel® AI Boost | Ubuntu 24.04.3 LTS (HWE) with kernel version 6.17
+ [Panther Lake](https://www.intel.com/content/www/us/en/ark/products/codename/237132/products-formerly-panther-lake.html) | Intel® Core™ Ultra Processors - series 3 | Integrated Intel® Arc™ B390 GPU | Integrated Intel® AI Boost | Ubuntu 24.04.4 LTS with kernel version 6.17.0
 
 Additionally, Deep Learning Streamer releases are validated on the following
 discrete GPUs:
 
  Codename   | GPU                                | Operating system
 ------------|------------------------------------|----------------------------
- [Alchemist](https://www.intel.com/content/www/us/en/products/details/discrete-gpus/arc/arc-a-series/products.html) | Intel® Arc™ GPU Series A | Ubuntu 22.04.5 LTS with kernel version 6.8.0-85<br>Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
- [Battlemage](https://www.intel.com/content/www/us/en/ark/products/series/240391/intel-arc-b-series-graphics.html) | Intel® Arc™ GPU Series B | Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
- [Battlemage Pro](https://www.intel.com/content/www/us/en/products/docs/discrete-gpus/arc/workstations/b-series/overview.html) | Intel® Arc™ Pro GPU Series B | Ubuntu 24.04.3 LTS (HWE) with kernel version 6.14.0-33
+ [Alchemist](https://www.intel.com/content/www/us/en/products/details/discrete-gpus/arc/arc-a-series/products.html) | Ubuntu 24.04.4 LTS with kernel version 6.17.0
+ [Battlemage](https://www.intel.com/content/www/us/en/ark/products/series/240391/intel-arc-b-series-graphics.html) | Intel® Arc™ GPU Series B | Ubuntu 24.04.4 LTS with kernel version 6.17.0
+ [Battlemage Pro](https://www.intel.com/content/www/us/en/products/docs/discrete-gpus/arc/workstations/b-series/overview.html) | Intel® Arc™ Pro GPU Series B | Ubuntu 24.04.4 LTS with kernel version 6.17.0
 
 To see the full list of potentially supported platforms, please refer to
 [OpenVINO™ System Requirements](https://www.intel.com/content/www/us/en/developer/tools/openvino-toolkit/system-requirements.html)


### PR DESCRIPTION
Update system requirements documentation to reflect validated OS/kernel changes: bump Ubuntu HWE entries from 24.04.3 to 24.04.4 and update validated kernel versions to 6.17.0 (normalize 22.04.5 kernel string to 6.8.0). Also update discrete GPU validation rows (Alchemist, Battlemage, Battlemage Pro) to reference Ubuntu 24.04.4 with kernel 6.17.0 and adjust Panther/Meteor/Lunar/Arrow/Tiger rows accordingly.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

