### PR TITLE
[GST gvawatermark] document explicit enable-blur flag usage

### DIFF
--- a/docs/user-guide/elements/gvawatermark.md
+++ b/docs/user-guide/elements/gvawatermark.md
@@ -77,6 +77,7 @@ Element Properties:
                         * show-roi=<string> colon-separated list of labels to include (only these objects will be shown), default empty
                         * hide-roi=<string> colon-separated list of labels to exclude (these objects will be hidden), default empty
                         * enable-blur=<bool> enable ROI blurring for privacy protection, default false
+                          NOTE : Blurring is applied only when "enable-blur=true"; if no "show-blur-roi" / "hide-blur-roi" filters are set, all ROIs are blurred
                           NOTE : show-blur-roi takes precedence over hide-blur-roi when both are specified
                           NOTE : this option is supported only for CPU for now.
                         * show-blur-roi=<string> colon-separated list of object labels to blur (e.g., "face:person")
@@ -191,7 +192,8 @@ The gvawatermark element supports privacy protection through region of interest 
 
 Blur functionality is controlled through the `displ-cfg` parameter with these options:
 
-- **enable-blur=<bool\>** - Enable or disable blur feature (default: false)
+- **enable-blur=<bool\>** - Enable or disable blur feature (default: false) Blurring is applied only when "enable-blur=true"; if no "show-blur-roi" / "hide-blur-roi" filters are set, all ROIs are blurred.
+
 - **show-blur-roi=<string\>** - Colon-separated list of object labels to blur (e.g., "person:face")
 - **hide-blur-roi=<string\>** - Colon-separated list of object labels to exclude from blurring
 

--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.h
@@ -87,6 +87,8 @@ enum { PROP_0, PROP_DEVICE, PROP_OBB, PROP_DISPL_AVGFPS, PROP_DISPL_CFG };
     "\t\t\thide-roi=<string> colon-separated list of labels to exclude (these objects will be hidden), default "       \
     "empty\n"                                                                                                          \
     "\t\t\tenable-blur=<bool> enable or disable ROI blurring for privacy protection, default false\n"                  \
+    "\t\t\tBlurring is applied only when `enable-blur=true`\n"                                                         \
+    "\t\t\tif no `show-blur-roi` / `hide-blur-roi` filters are set, all ROIs are blurred.\n"                           \
     "\t\t\tshow-blur-roi=<string> colon-separated list of object labels to blur (e.g. 'face:person')\n"                \
     "\t\t\thide-blur-roi=<string> colon-separated list of object labels to exclude from blurring\n"                    \
     "\t\t\tNOTE: show-blur-roi takes precedence over hide-blur-roi when both are specified\n"                          \


### PR DESCRIPTION
### Description

update gvawatermark documentation to explicit the need for "enable-blur" flag to enable the blurring feature either ROI blur filter is enabled or not.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

