### PR TITLE
CI rework - remove weekly schedule from DLS models workflow

### DIFF
--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -1,8 +1,6 @@
 name: "[DLS] Models update on self-hosted runners"
 run-name: "[DLS] Models update on self-hosted runners (by @${{ github.actor }} via ${{ github.event_name }})"
 on:
-  schedule:
-    - cron: '0 5 * * MON' # 5:00 UTC each Monday
   workflow_dispatch:
     inputs:
       models_to_download:


### PR DESCRIPTION
Disable the automated weekly cron trigger (was '0 5 * * MON') for the self-hosted DLS models update workflow. The workflow remains runnable via workflow_dispatch with the existing inputs to allow manual or on-demand runs.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

