### PR TITLE
Improve performance on NPU related to segfault with dual inference pipeline on yolo11s

### DIFF
--- a/src/gst/elements/gvafpscounter/fpscounter_c.cpp
+++ b/src/gst/elements/gvafpscounter/fpscounter_c.cpp
@@ -68,6 +68,7 @@ void fps_counter_create_readpipe(void *fpscounter, const char *pipe_name) {
         if (not fps_counters.count("readpipe")) {
             auto pipe_complete_lambda = [=]() {
                 fps_counter_eos(GST_ELEMENT_NAME(GST_BASE_TRANSFORM(fpscounter)));
+                // Pushing an EOS event downstream to signal that we're done.
                 bool handled = gst_pad_push_event(GST_BASE_TRANSFORM(fpscounter)->srcpad, gst_event_new_eos());
                 if (!handled)
                     throw std::runtime_error("FpsCounter ReadPipe: EOS event wasn't handled. Spinning...");

--- a/src/gst/elements/gvafpscounter/fpscounter_c.cpp
+++ b/src/gst/elements/gvafpscounter/fpscounter_c.cpp
@@ -41,10 +41,10 @@ void fps_counter_create_iterative(const char *intervals, bool print_std_dev, boo
 
 void fps_counter_create_average(unsigned int starting_frame, unsigned int interval) {
     try {
+        std::lock_guard<std::mutex> lock(channels_mutex);
         if (not fps_counters.count("average")) {
-            std::shared_ptr<FpsCounter> fps_counter = nullptr;
-            fps_counter = std::make_shared<IterativeFpsCounter>(starting_frame, interval, true, false, false);
-            fps_counters.insert({"average", fps_counter});
+            fps_counters.insert(
+                {"average", std::make_shared<IterativeFpsCounter>(starting_frame, interval, true, false, false)});
         }
     } catch (std::exception &e) {
         GVA_ERROR("Error during creation average fpscounter: %s", Utils::createNestedErrorMsg(e).c_str());
@@ -53,10 +53,9 @@ void fps_counter_create_average(unsigned int starting_frame, unsigned int interv
 
 void fps_counter_create_writepipe(const char *pipe_name) {
     try {
+        std::lock_guard<std::mutex> lock(channels_mutex);
         if (not fps_counters.count("writepipe")) {
-            std::shared_ptr<FpsCounter> fps_counter = nullptr;
-            fps_counter = std::make_shared<WritePipeFpsCounter>(pipe_name);
-            fps_counters.insert({"writepipe", fps_counter});
+            fps_counters.insert({"writepipe", std::make_shared<WritePipeFpsCounter>(pipe_name)});
         }
     } catch (std::exception &e) {
         GVA_ERROR("Error during creation writepipe fpscounter: %s", Utils::createNestedErrorMsg(e).c_str());
@@ -65,18 +64,17 @@ void fps_counter_create_writepipe(const char *pipe_name) {
 
 void fps_counter_create_readpipe(void *fpscounter, const char *pipe_name) {
     try {
+        std::lock_guard<std::mutex> lock(channels_mutex);
         if (not fps_counters.count("readpipe")) {
             auto pipe_complete_lambda = [=]() {
                 fps_counter_eos(GST_ELEMENT_NAME(GST_BASE_TRANSFORM(fpscounter)));
-                // Pushing an EOS event downstream to signal that we're done.
                 bool handled = gst_pad_push_event(GST_BASE_TRANSFORM(fpscounter)->srcpad, gst_event_new_eos());
                 if (!handled)
                     throw std::runtime_error("FpsCounter ReadPipe: EOS event wasn't handled. Spinning...");
             };
             auto new_message_lambda = [](const char *name) { fps_counter_new_frame(NULL, name, NULL); };
-            std::shared_ptr<FpsCounter> fps_counter = nullptr;
-            fps_counter = std::make_shared<ReadPipeFpsCounter>(pipe_name, new_message_lambda, pipe_complete_lambda);
-            fps_counters.insert({"readpipe", fps_counter});
+            fps_counters.insert({"readpipe", std::make_shared<ReadPipeFpsCounter>(pipe_name, new_message_lambda,
+                                                                                  pipe_complete_lambda)});
         }
     } catch (std::exception &e) {
         GVA_ERROR("Error during creation readpipe fpscounter: %s", Utils::createNestedErrorMsg(e).c_str());
@@ -85,6 +83,7 @@ void fps_counter_create_readpipe(void *fpscounter, const char *pipe_name) {
 
 void fps_counter_new_frame(GstBuffer *buffer, const char *element_name, void *gstgvafpscounter) {
     try {
+        std::lock_guard<std::mutex> lock(channels_mutex);
         for (auto counter = fps_counters.begin(); counter != fps_counters.end(); ++counter) {
             counter->second->NewFrame(element_name, output, buffer);
             if (gstgvafpscounter && counter->first == "average") {
@@ -102,6 +101,7 @@ void fps_counter_new_frame(GstBuffer *buffer, const char *element_name, void *gs
 
 void fps_counter_eos(const char *element_name) {
     try {
+        std::lock_guard<std::mutex> lock(channels_mutex);
         for (auto counter = fps_counters.begin(); counter != fps_counters.end(); ++counter)
             counter->second->EOS(element_name, output);
     } catch (std::exception &e) {

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -820,6 +820,22 @@ class OpenVinoNewApiImpl {
             }
         }
 
+        // NPU achieves throughput via multiple async inference requests rather than
+        // model-level batching. A static batched graph (ov::set_batch(N>1)) hurts
+        // performance by ~3x and can fail the VCL compiler for N>=16. Translate the
+        // user's batch-size into nireq so the NPU sees a batch-1 graph.
+        // NPU saturates at ~4 concurrent async requests; use that as a lower bound.
+        static constexpr int NPU_MIN_NIREQ = 4;
+        if (_device.find("NPU") != std::string::npos && _batch_size > 1) {
+            int requested_nireq = std::max(_batch_size, NPU_MIN_NIREQ);
+            if (_nireq == 0 || _nireq < requested_nireq)
+                _nireq = requested_nireq;
+            GVA_WARNING("NPU: model-level batching is inefficient on NPU hardware. "
+                        "Clamping batch-size from %d to 1 and using nireq=%d for async throughput.",
+                        _batch_size, _nireq);
+            _batch_size = 1;
+        }
+
         _batch_timeout = config.batch_timeout();
 
         if (_batch_timeout > -1) {
@@ -1078,10 +1094,7 @@ class OpenVinoNewApiImpl {
         }
 
         // print_input_and_outputs_info(*_model);
-        {
-            // npu plugin init is not re-entrant — serialize compile_model for npu only
-            auto lock =
-                is_device_npu() ? std::unique_lock<std::mutex>(compile_mutex()) : std::unique_lock<std::mutex>();
+        auto do_compile = [&]() {
             if (_openvino_context) {
                 _compiled_model = core().compile_model(_model, _openvino_context->remote_context(), ov_params);
             } else {
@@ -1091,6 +1104,12 @@ class OpenVinoNewApiImpl {
                 }
                 _compiled_model = core().compile_model(_model, formatted_device, ov_params);
             }
+        };
+        if (_device.find("NPU") != std::string::npos) {
+            std::lock_guard<std::mutex> lock(compile_mutex());
+            do_compile();
+        } else {
+            do_compile();
         }
         GVA_INFO("Network loaded to device");
 
@@ -1127,10 +1146,6 @@ class OpenVinoNewApiImpl {
 
     bool is_device_gpu() const {
         return _device.find("GPU") != std::string::npos;
-    }
-
-    bool is_device_npu() const {
-        return _device.find("NPU") != std::string::npos;
     }
 
     bool is_device_multi() const {

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -42,6 +42,7 @@
 
 #include <functional>
 #include <iterator>
+#include <mutex>
 #include <regex>
 #include <stdio.h>
 #include <thread>
@@ -754,10 +755,16 @@ class OpenVinoNewApiImpl {
         return 0;
     }
 
-    // Singleton core object
     static ov::Core &core() {
         static ov::Core ovcore;
         return ovcore;
+    }
+
+    // Serializes compile_model / create_context calls that trigger device plugin init.
+    // read_model is intentionally NOT serialized — it is a pure XML parse.
+    static std::mutex &compile_mutex() {
+        static std::mutex m;
+        return m;
     }
 
   protected:
@@ -809,7 +816,7 @@ class OpenVinoNewApiImpl {
             try {
                 _batch_size = core().get_property(config.device(), ov::optimal_batch_size);
             } catch (...) {
-                _batch_size = 1; // Fallback if optimal batch size property is not supported
+                _batch_size = 1;
             }
         }
 
@@ -1071,14 +1078,17 @@ class OpenVinoNewApiImpl {
         }
 
         // print_input_and_outputs_info(*_model);
-        if (_openvino_context) {
-            _compiled_model = core().compile_model(_model, _openvino_context->remote_context(), ov_params);
-        } else {
-            std::string formatted_device = _device;
-            if (_batch_timeout > -1) {
-                formatted_device = fmt::format("BATCH:{}({})", _device, _auto_batch_num_requests);
+        {
+            std::lock_guard<std::mutex> lock(compile_mutex());
+            if (_openvino_context) {
+                _compiled_model = core().compile_model(_model, _openvino_context->remote_context(), ov_params);
+            } else {
+                std::string formatted_device = _device;
+                if (_batch_timeout > -1) {
+                    formatted_device = fmt::format("BATCH:{}({})", _device, _auto_batch_num_requests);
+                }
+                _compiled_model = core().compile_model(_model, formatted_device, ov_params);
             }
-            _compiled_model = core().compile_model(_model, formatted_device, ov_params);
         }
         GVA_INFO("Network loaded to device");
 
@@ -1129,6 +1139,7 @@ class OpenVinoNewApiImpl {
                 if (_app_context) {
                     try {
                         dlstreamer::D3D11ContextPtr d3d11_ctx = dlstreamer::D3D11Context::create(_app_context);
+                        std::lock_guard<std::mutex> lock(compile_mutex());
                         _openvino_context = std::make_shared<dlstreamer::OpenVINOContext>(core(), _device, d3d11_ctx);
                     } catch (std::exception &e) {
                         GVA_ERROR("Exception occurred when creating OpenVINO™ toolkit remote context: %s", e.what());
@@ -1144,6 +1155,7 @@ class OpenVinoNewApiImpl {
                 if (_app_context) {
                     try {
                         dlstreamer::VAAPIContextPtr vaapi_ctx = dlstreamer::VAAPIContext::create(_app_context);
+                        std::lock_guard<std::mutex> lock(compile_mutex());
                         _openvino_context = std::make_shared<dlstreamer::OpenVINOContext>(core(), _device, vaapi_ctx);
                     } catch (std::exception &e) {
                         GVA_ERROR("Exception occurred when creating OpenVINO™ toolkit remote context: %s", e.what());

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -816,7 +816,7 @@ class OpenVinoNewApiImpl {
             try {
                 _batch_size = core().get_property(config.device(), ov::optimal_batch_size);
             } catch (...) {
-                _batch_size = 1;
+                _batch_size = 1; // Fallback if optimal batch size property is not supported
             }
         }
 
@@ -1079,7 +1079,9 @@ class OpenVinoNewApiImpl {
 
         // print_input_and_outputs_info(*_model);
         {
-            std::lock_guard<std::mutex> lock(compile_mutex());
+            // npu plugin init is not re-entrant — serialize compile_model for npu only
+            auto lock =
+                is_device_npu() ? std::unique_lock<std::mutex>(compile_mutex()) : std::unique_lock<std::mutex>();
             if (_openvino_context) {
                 _compiled_model = core().compile_model(_model, _openvino_context->remote_context(), ov_params);
             } else {
@@ -1127,6 +1129,10 @@ class OpenVinoNewApiImpl {
         return _device.find("GPU") != std::string::npos;
     }
 
+    bool is_device_npu() const {
+        return _device.find("NPU") != std::string::npos;
+    }
+
     bool is_device_multi() const {
         return _device.find("MULTI") != std::string::npos;
     }
@@ -1139,7 +1145,6 @@ class OpenVinoNewApiImpl {
                 if (_app_context) {
                     try {
                         dlstreamer::D3D11ContextPtr d3d11_ctx = dlstreamer::D3D11Context::create(_app_context);
-                        std::lock_guard<std::mutex> lock(compile_mutex());
                         _openvino_context = std::make_shared<dlstreamer::OpenVINOContext>(core(), _device, d3d11_ctx);
                     } catch (std::exception &e) {
                         GVA_ERROR("Exception occurred when creating OpenVINO™ toolkit remote context: %s", e.what());
@@ -1155,7 +1160,6 @@ class OpenVinoNewApiImpl {
                 if (_app_context) {
                     try {
                         dlstreamer::VAAPIContextPtr vaapi_ctx = dlstreamer::VAAPIContext::create(_app_context);
-                        std::lock_guard<std::mutex> lock(compile_mutex());
                         _openvino_context = std::make_shared<dlstreamer::OpenVINOContext>(core(), _device, vaapi_ctx);
                     } catch (std::exception &e) {
                         GVA_ERROR("Exception occurred when creating OpenVINO™ toolkit remote context: %s", e.what());


### PR DESCRIPTION
## Description

When two `gvadetect` pipelines target `device=NPU` simultaneously, the NPU VCL compiler crashes with `ConvertVPUMI37XX2ELF failed: bad optional access` followed by SIGSEGV. This limitation is coming from the NPU compiler itself.

The current intent of this PR is to introduce clamping to batch-size of 1 for NPUs since it helps achieve better performance in DL Streamer.

### Reproduction

**Single pipeline:**

```bash
MODEL_PATH=/path/to/yolo11s/INT8/yolo11s.xml
VIDEO_PATH=/path/to/1192116-sd_640_360_30fps.mp4

gst-launch-1.0 \
  filesrc location=$VIDEO_PATH \
  ! qtdemux ! h264parse ! vaapidecodebin \
  ! vapostproc ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! gvadetect model=$MODEL_PATH pre-process-backend=va device=NPU batch-size=8 nireq=6 \
  ! gvafpscounter \
  ! fakesink sync=false
```

**Dual pipeline:**

```bash
MODEL_PATH=/path/to/yolo11s/INT8/yolo11s.xml
VIDEO_PATH=/path/to/1192116-sd_640_360_30fps.mp4

gst-launch-1.0 \
  filesrc location=$VIDEO_PATH \
  ! qtdemux ! h264parse ! vaapidecodebin \
  ! vapostproc ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! gvadetect model=$MODEL_PATH pre-process-backend=va device=NPU batch-size=8 nireq=6 \
  ! gvafpscounter \
  ! fakesink sync=false \
  filesrc location=$VIDEO_PATH \
  ! qtdemux ! h264parse ! vaapidecodebin \
  ! vapostproc ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! vapostproc \
  ! 'video/x-raw(memory:VAMemory)' \
  ! gvadetect model=$MODEL_PATH pre-process-backend=va device=NPU batch-size=8 nireq=6 \
  ! gvafpscounter \
  ! fakesink sync=false
```

**upd:** after thorough benchmarking on arl-h, and trying locking mutexes for npu the sigsegv described in does not reproduce on current main. dual gvadetect pipeline completes successfully for batch-sizes 1 through 8.  with issues from compiler observed for batch sizes of 4 and 8.
the proposed compile_mutex fix shows marginal performance benefit vs main. benchmarks are within noise; some cases are marginally slower with the lock.
batch-size 16/32 still fails, but it's an npu vcl compiler issue, escalating to NPU compiler team. 

benchmarks [fps] with previously tried fixes:
| batch | single fix | single main | dual fix | dual main |
|-------|-----------|-------------|----------|-----------|
| 1     | 90.49     | 90.18       | 88.95    | 88.98     |
| 2     | 29.58     | 29.67       | 32.25    | 38.09     |
| 4     | 31.40     | 31.23       | 19.74    | 20.05     |
| 8     | 26.16     | 25.94       | 30.69    | 30.71     |

so, at the end, either just clamping to 1, because this allows for the best performance in DL Streamer,
or figuring out better how to optimize in this case for throughput on NPUs
benchmarks  then everytime around ~90 fps

**upd2:** committed a workaround that maps batch size to nireq for async throughput

### How Has This Been Tested?

Locally on ARL-H with Intel Core Ultra 9 285H.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.