### PR TITLE
CI: switch ubuntu24 runner labels to ARL

### DIFF
--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -73,12 +73,6 @@ jobs:
                 {
                   "path_dockerfile": "./dlstreamer/docker/ubuntu/ubuntu24.Dockerfile",
                   "ubuntu_version": "ubuntu24",
-                  "runner_labels": ["tgl-ubuntu24"],
-                  "runner_print_label": "TGL"
-                },
-                {
-                  "path_dockerfile": "./dlstreamer/docker/ubuntu/ubuntu24.Dockerfile",
-                  "ubuntu_version": "ubuntu24",
                   "runner_labels": ["arl-ubuntu24"],
                   "runner_print_label": "ARL"
                 }

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -56,10 +56,10 @@ jobs:
                   "runner_print_label": "TGL"
                 },
                 {
-                  "path_dockerfile": "./dlstreamer-repo/docker/ubuntu/ubuntu24.Dockerfile",
+                  "path_dockerfile": "./dlstreamer/docker/ubuntu/ubuntu24.Dockerfile",
                   "ubuntu_version": "ubuntu24",
-                  "runner_labels": ["tgl-ubuntu24"],
-                  "runner_print_label": "TGL"
+                  "runner_labels": ["arl-ubuntu24"],
+                  "runner_print_label": "ARL"
                 }
               ]
             }' | jq -c .)

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -56,7 +56,7 @@ jobs:
                   "runner_print_label": "TGL"
                 },
                 {
-                  "path_dockerfile": "./dlstreamer/docker/ubuntu/ubuntu24.Dockerfile",
+                  "path_dockerfile": "./dlstreamer-repo/docker/ubuntu/ubuntu24.Dockerfile",
                   "ubuntu_version": "ubuntu24",
                   "runner_labels": ["arl-ubuntu24"],
                   "runner_print_label": "ARL"

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -67,8 +67,8 @@ jobs:
                 {
                   "path_dockerfile": "./dlstreamer/docker/ubuntu/ubuntu24.Dockerfile",
                   "ubuntu_version": "ubuntu24",
-                  "runner_labels": ["tgl-ubuntu24"],
-                  "runner_print_label": "TGL"
+                  "runner_labels": ["arl-ubuntu24"],
+                  "runner_print_label": "ARL"
                 }
               ]
             }' | jq -c .)


### PR DESCRIPTION
Update GitHub Actions workflows to route ubuntu24 jobs to ARL runners and fix a Dockerfile path. Changes:
- .github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml: remove duplicate ubuntu24 job entry.
- .github/workflows/dls-build-dev-docker-images-and-run-unit.yaml: correct Dockerfile path (dlstreamer) and change runner_labels/runner_print_label from tgl-ubuntu24/TGL to arl-ubuntu24/ARL.
- .github/workflows/dls-test-optimizer.yaml: change runner_labels/runner_print_label from tgl-ubuntu24/TGL to arl-ubuntu24/ARL. These edits ensure ubuntu24 jobs use the intended ARL runners and the correct Dockerfile location.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

