### PR TITLE
Fix CI WinGet PowerShell module crash

### DIFF
--- a/scripts/build_dlstreamer_dlls.ps1
+++ b/scripts/build_dlstreamer_dlls.ps1
@@ -391,10 +391,10 @@ else {
 # ============================================================================
 # Git
 # ============================================================================
-$gitInstalled = (Get-WinGetPackage -Id Git.Git -Source winget -ErrorAction SilentlyContinue).Count -gt 0
+$gitInstalled = $null -ne (Get-Command git -ErrorAction SilentlyContinue)
 if (-Not $gitInstalled) {
 	Write-Section "Installing Git"
-	Install-WinGetPackage -Id Git.Git -Source winget -Mode Silent
+	winget install --id Git.Git --source winget --silent --accept-package-agreements --accept-source-agreements
 	Update-Path
 	New-ItemProperty -Path "HKLM:\SYSTEM\CurrentControlSet\Control\FileSystem" -Name "LongPathsEnabled" -Value 1 -PropertyType DWORD -Force
 	git config --system core.longpaths true
@@ -408,10 +408,10 @@ else {
 # ============================================================================
 # CMake
 # ============================================================================
-$cmakeInstalled = (Get-WinGetPackage -Id Kitware.CMake -Source winget -ErrorAction SilentlyContinue).Count -gt 0
+$cmakeInstalled = $null -ne (Get-Command cmake -ErrorAction SilentlyContinue)
 if (-Not $cmakeInstalled) {
 	Write-Section "Installing CMake"
-	Install-WinGetPackage -Id Kitware.CMake -Source winget -Mode Silent
+	winget install --id Kitware.CMake --source winget --silent --accept-package-agreements --accept-source-agreements
 	Update-Path
 	Write-Section "Done"
 }


### PR DESCRIPTION
### Description

Fixes # (issue)

Stack buffer overrun crash (exit code -1073740791)
Replace Get-WinGetPackage and Install-WinGetPackage with winget.exe CLI.

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

