### PR TITLE
Schedule weekly DLS models sync (Mon 06:00)

### DIFF
--- a/.github/workflows/dls-download-models.yaml
+++ b/.github/workflows/dls-download-models.yaml
@@ -1,6 +1,8 @@
 name: "[DLS] Models sync status check"
 run-name: "[DLS] Models sync status check (by @${{ github.actor }} via ${{ github.event_name }})"
 on:
+  schedule:
+    - cron: '0 6 * * 1'
   workflow_dispatch:
 
 permissions: {}


### PR DESCRIPTION
Add a scheduled trigger to the DLS models sync workflow to run every Monday at 06:00 UTC (cron '0 6 * * 1'). The manual workflow_dispatch trigger is retained and no other changes were made.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

