### PR TITLE
Add missing documentation about add-rtp-timestamp in gvametaconvert properties

### DIFF
--- a/docs/user-guide/elements/gvametaconvert.md
+++ b/docs/user-guide/elements/gvametaconvert.md
@@ -27,6 +27,9 @@ Element Properties:
   add-empty-results     : Add metadata when inference is run but no results meet the detection threshold
                           flags: readable, writable
                           Boolean. Default: false
+  add-rtp-timestamp     : Include NTP reference timestamp metadata from RTCP Sender Reports in output. Requires add-reference-timestamp-meta=true in rtspsrc.
+                          flags: readable, writable
+                          Boolean. Default: false
   add-tensor-data       : Add raw tensor data in addition to detection and classification labels.
                           flags: readable, writable
                           Boolean. Default: false


### PR DESCRIPTION

### Description

Added  missing property to metaconvert documentation


### Any Newly Introduced Dependencies

N/A

### How Has This Been Tested?

N/A

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

