### PR TITLE
[GST watermark] use dynamic Gaussian blur kernel sized to ROI

### DIFF
--- a/src/monolithic/gst/elements/gvawatermark/renderer/cpu/renderer_cpu.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/cpu/renderer_cpu.cpp
@@ -12,8 +12,18 @@
 
 namespace {
 
-const int sigmaX = 15;
-const int sigmaY = 15;
+// Compute a Gaussian blur kernel size proportional to the ROI so that larger
+// regions get a stronger blur.  The kernel must be positive and odd for
+// cv::GaussianBlur.  Using ~1/5 of each dimension with a minimum of 7
+// keeps small objects blurred while scaling up for bigger regions.
+cv::Size computeBlurKernelSize(int roi_width, int roi_height) {
+    int kw = std::max(7, roi_width / 5);
+    int kh = std::max(7, roi_height / 5);
+    // Ensure odd
+    kw = kw | 1;
+    kh = kh | 1;
+    return cv::Size(kw, kh);
+}
 
 const std::vector<cv::Vec3b> PascalVoc21ClColorPalette = {
     cv::Vec3b(0, 0, 0),       // background
@@ -168,15 +178,17 @@ void RendererI420::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur)
     cv::Mat &v = mats[2];
 
     cv::Rect r = blur.rect;
+    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
+    cv::Size ksize_uv = computeBlurKernelSize(r.width / 2, r.height / 2);
 
     cv::Mat roi_u(u, cv::Rect(r.x / 2, r.y / 2, r.width / 2, r.height / 2));
-    cv::GaussianBlur(roi_u, roi_u, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi_u, roi_u, ksize_uv, 0, 0);
 
     cv::Mat roi_v(v, cv::Rect(r.x / 2, r.y / 2, r.width / 2, r.height / 2));
-    cv::GaussianBlur(roi_v, roi_v, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi_v, roi_v, ksize_uv, 0, 0);
 
     cv::Mat roi_y(y, cv::Rect(r.x, r.y, r.width, r.height));
-    cv::GaussianBlur(roi_y, roi_y, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi_y, roi_y, ksize, 0, 0);
 }
 
 void RendererI420::draw_rectangle(std::vector<cv::Mat> &mats, render::Rect rect) {
@@ -305,12 +317,14 @@ void RendererNV12::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur)
     cv::Mat &u_v = mats[1];
 
     cv::Rect r = blur.rect;
+    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
+    cv::Size ksize_uv = computeBlurKernelSize(r.width / 2, r.height / 2);
 
     cv::Mat roi_uv(u_v, cv::Rect(r.x / 2, r.y / 2, r.width / 2, r.height / 2));
-    cv::GaussianBlur(roi_uv, roi_uv, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi_uv, roi_uv, ksize_uv, 0, 0);
 
     cv::Mat roi(y, cv::Rect(r.x, r.y, r.width, r.height));
-    cv::GaussianBlur(roi, roi, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi, roi, ksize, 0, 0);
 }
 
 void RendererNV12::draw_rectangle(std::vector<cv::Mat> &mats, render::Rect rect) {
@@ -477,8 +491,9 @@ void RendererBGR::draw_rectangle(std::vector<cv::Mat> &mats, render::Rect rect) 
 void RendererBGR::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur) {
     cv::Mat &mat = mats[0];
     cv::Rect r = blur.rect;
+    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
     cv::Mat roi(mat, cv::Rect(r.x, r.y, r.width, r.height));
-    cv::GaussianBlur(roi, roi, cv::Size(sigmaX, sigmaY), 0, 0);
+    cv::GaussianBlur(roi, roi, ksize, 0, 0);
 }
 
 void RendererBGR::draw_circle(std::vector<cv::Mat> &mats, render::Circle circle) {


### PR DESCRIPTION
### Description

The static 15×15 kernel was insufficient for large bounding boxes, leaving detected objects still recognizable after blurring.  Compute the kernel size as ~1/5 of each ROI dimension (minimum 7, always odd) so the blur strength scales with the region.  Applied to all three renderer paths (I420, NV12, BGR/BGRx/BGRA).

Fixes #817 

### Any Newly Introduced Dependencies

NO

### How Has This Been Tested?

the video used to depict the issue is used to show the result of new kernel adaptive size

https://github.com/user-attachments/assets/9740d7e2-ffbc-4c7a-850b-53deea395cd6

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.