### PR TITLE
Install optimizer requirements in Docker images and CI workflow

### DIFF
--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -249,6 +249,7 @@ jobs:
       - name: Install optimizer requirements on host
         if: always() && matrix.runner_print_label != 'SKIP'
         run: |
+          sudo apt-get install -y --no-install-recommends libcairo2-dev libgirepository1.0-dev
           python3 -m venv $HOME/optimizer-venv
           $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
           echo "$HOME/optimizer-venv/bin" >> $GITHUB_PATH

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -250,8 +250,7 @@ jobs:
         if: always() && matrix.runner_print_label != 'SKIP'
         run: |
           sudo apt-get install -y --no-install-recommends libcairo2-dev libgirepository1.0-dev
-          python3 -m venv $HOME/optimizer-venv
-          pip install openvino
+          python3 -m venv --system-site-packages $HOME/optimizer-venv
           $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
           echo "$HOME/optimizer-venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -249,9 +249,9 @@ jobs:
       - name: Install optimizer requirements on host
         if: always() && matrix.runner_print_label != 'SKIP'
         run: |
-          python3 -m venv /opt/optimizer-venv
-          /opt/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
-          echo "/opt/optimizer-venv/bin" >> $GITHUB_PATH
+          python3 -m venv $HOME/optimizer-venv
+          $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
+          echo "$HOME/optimizer-venv/bin" >> $GITHUB_PATH
 
       - name: Run Optimizer on host
         if: always() && matrix.runner_print_label != 'SKIP'

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -246,6 +246,13 @@ jobs:
         run: |
           $DLS_REL_PATH/tests/scripts/installation-on-host-entrypoint.sh $DLS_REL_PATH/deb_packages
 
+      - name: Install optimizer requirements on host
+        if: always() && matrix.runner_print_label != 'SKIP'
+        run: |
+          python3 -m venv /opt/optimizer-venv
+          /opt/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
+          echo "/opt/optimizer-venv/bin" >> $GITHUB_PATH
+
       - name: Run Optimizer on host
         if: always() && matrix.runner_print_label != 'SKIP'
         id: run_optimizer_on_host

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -251,6 +251,7 @@ jobs:
         run: |
           sudo apt-get install -y --no-install-recommends libcairo2-dev libgirepository1.0-dev
           python3 -m venv $HOME/optimizer-venv
+          pip install openvino
           $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
           echo "$HOME/optimizer-venv/bin" >> $GITHUB_PATH
 

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -400,6 +400,8 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
+RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
+
 WORKDIR $DLSTREAMER_DIR/build
 
 # DLStreamer environment variables

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -394,9 +394,8 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
-RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
-
-RUN mkdir build
+RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt" && \
+    mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build
 

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -394,6 +394,8 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
+RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
+
 RUN mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -403,6 +403,8 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
+RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
+
 RUN mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -403,9 +403,8 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
-RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
-
-RUN mkdir build
+RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt" && \
+    mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build
 


### PR DESCRIPTION
### Description

Add installation of optimizer Python requirements for CI host and Docker images. The workflow now creates a venv (/opt/optimizer-venv), installs requirements from /opt/intel/dlstreamer/scripts/optimizer/requirements.txt, and appends the venv bin to GITHUB_PATH (run only when matrix.runner_print_label != 'SKIP'). The Fedora41, Ubuntu22 and Ubuntu24 Dockerfiles also install the same requirements via /python3venv/bin/pip3 after copying the repository. This ensures optimizer dependencies are available when running the Optimizer in tests and images.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

