### PR TITLE
Prepend directories to PATH, fix GStreamer cache cleaning

### DIFF
--- a/cmake/packaging/windows/dlstreamer.nsh
+++ b/cmake/packaging/windows/dlstreamer.nsh
@@ -284,7 +284,11 @@ Function LegacyCleanUp
 
   ; Clean temporary folders
   RMDir /r 'C:\dlstreamer_tmp'
+
+  ; Clean GStreamer cache
+  SetShellVarContext current
   RMDir /r '$LOCALAPPDATA\Microsoft\Windows\INetCache\gstreamer-1.0'
+  SetShellVarContext all
 
   ; Uninstall GStreamer MSI (GStreamer < 1.28)
   Push '{C20A66DC-B249-4E6D-A68A-D0F836B2B3CF}'  ; GStreamer runtime
@@ -351,7 +355,6 @@ FunctionEnd
   InvokeGStreamerInstaller:
   SetOutPath '$INSTDIR\deps'
   File '${INSTALLER_DEPS_DIR}\gstreamer-1.0-msvc-x86_64-${GSTREAMER_VERSION}.exe'
-  SetOutPath '$INSTDIR'
 
   Push '${GSTREAMER_INSTALLER_HASH}'
   Push '$INSTDIR\deps\gstreamer-1.0-msvc-x86_64-${GSTREAMER_VERSION}.exe'
@@ -369,28 +372,26 @@ FunctionEnd
     MessageBox MB_OK|MB_ICONEXCLAMATION 'Failed to install GStreamer.' /SD IDYES
   ${EndIf}
 
+  ; Result: 0=equal, 1=installed newer, 2=bundled newer
+  ${VersionCompare} '1.28.2' '${GSTREAMER_VERSION}' $R4
+  ${If} $R4 = 0
+    ReadRegStr $R2 HKLM 'SOFTWARE\GStreamer1.0\x86_64' 'InstallDir'
+    SetOutPath $R2\bin
+    File "${INST_DIR}\c00_gstreamer\deps\windows\gstanalytics-1.0-0.dll"
+  ${EndIf}
+
+  SetOutPath '$INSTDIR'
+
   SkipGStreamer:
 !macroend
 
 Function SetupEnvironmentVariables
   DetailPrint 'Setup environment variables'
-
-  ; Setup environment variables
-  WriteRegExpandStr HKCU 'Environment' 'DLSTREAMER_DIR' '$INSTDIR'
-  WriteRegExpandStr HKCU 'Environment' 'GST_PLUGIN_PATH' '$INSTDIR\bin'
-
-  ; Add to user PATH
-  ReadRegStr $R2 HKLM 'SOFTWARE\GStreamer1.0\x86_64' 'InstallDir'
-  EnVar::SetHKCU
-  EnVar::AddValue 'Path' '$R2\bin'
+  nsExec::ExecToLog 'powershell.exe -ExecutionPolicy Bypass -File "$INSTDIR\scripts\setup_dls_env.ps1" -Persist'
   Pop $0
-  EnVar::AddValue 'Path' '$INSTDIR\bin'
-  Pop $0
-
-  ; Populate plugin registry
-  DetailPrint 'Execute gst-inspect-1.0.exe to populate plugin registry'
-  nsExec::Exec '$R2\bin\gst-inspect-1.0.exe'
-  Pop $0
+  ${If} $0 != 0
+    DetailPrint 'Environment setup failed. Error code: $0'
+  ${EndIf}
 FunctionEnd
 
 Function InstallFinalize

--- a/cmake/packaging/windows/install_targets.cmake
+++ b/cmake/packaging/windows/install_targets.cmake
@@ -155,6 +155,10 @@ install(FILES ${CMAKE_BINARY_DIR}/gstreamer.txt
     DESTINATION deps
     COMPONENT c00_gstreamer
 )
+install(DIRECTORY ${CMAKE_SOURCE_DIR}/dependencies/windows
+    DESTINATION deps
+    COMPONENT c00_gstreamer
+)
 
 # Install OpenVINO runtime DLLs
 if(NOT OpenVINOGenAI_DIR)

--- a/scripts/setup_dls_env.ps1
+++ b/scripts/setup_dls_env.ps1
@@ -4,6 +4,10 @@
 # SPDX-License-Identifier: MIT
 # ==============================================================================
 
+param(
+	[switch]$Persist
+)
+
 Write-Host "`n=== DL Streamer Environment Setup ==="
 Write-Host 'Setting environment variables: DLSTREAMER_DIR, GST_PLUGIN_PATH, PATH'
 
@@ -32,14 +36,20 @@ If (-Not $envMsvcX64) {
 }
 $GSTREAMER_BIN_DIR = "$envMsvcX64\bin"
 
-$pathEntries = $env:PATH -split ';'
-if (-Not ($pathEntries -contains $DLL_DIR)) {
-	$env:PATH = $env:PATH + ';' + $DLL_DIR
-	Write-Host "Added to Path: $DLL_DIR"
-}
-if (-Not ($pathEntries -contains $GSTREAMER_BIN_DIR)) {
-	$env:PATH = $env:PATH + ';' + $GSTREAMER_BIN_DIR
-	Write-Host "Added to Path: $GSTREAMER_BIN_DIR"
+# Prepend DLL_DIR and GSTREAMER_BIN_DIR to PATH (move to front if already present)
+$pathEntries = $env:PATH -split ';' | Where-Object { $_ -and $_ -ne $DLL_DIR -and $_ -ne $GSTREAMER_BIN_DIR }
+$env:PATH = (@($DLL_DIR, $GSTREAMER_BIN_DIR) + $pathEntries) -join ';'
+Write-Host "Prepended to Path: $DLL_DIR"
+Write-Host "Prepended to Path: $GSTREAMER_BIN_DIR"
+
+if ($Persist) {
+	Write-Host "Persisting environment variables to user scope..."
+	[Environment]::SetEnvironmentVariable('DLSTREAMER_DIR', $DLSTREAMER_ROOT, [System.EnvironmentVariableTarget]::User)
+	[Environment]::SetEnvironmentVariable('GST_PLUGIN_PATH', $DLL_DIR, [System.EnvironmentVariableTarget]::User)
+	$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+	$userEntries = $userPath -split ';' | Where-Object { $_ -and $_ -ne $DLL_DIR -and $_ -ne $GSTREAMER_BIN_DIR }
+	$newUserPath = (@($DLL_DIR, $GSTREAMER_BIN_DIR) + $userEntries) -join ';'
+	[Environment]::SetEnvironmentVariable('Path', $newUserPath, [System.EnvironmentVariableTarget]::User)
 }
 
 # Check if gvadetect element is available


### PR DESCRIPTION
### Description

Appending directories to PATH (to last) might cause incompatibility if any directory contains DLLs with same name. Use prepend to workaround.
For GStreamer cache, use current user's folder, not global folder

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

