### PR TITLE
Use top-level requirements.txt in CI and images

### DIFF
--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -246,15 +246,15 @@ jobs:
         run: |
           $DLS_REL_PATH/tests/scripts/installation-on-host-entrypoint.sh $DLS_REL_PATH/deb_packages
 
-      - name: Install optimizer requirements on host
+      - name: Install requirements on host
         if: always() && matrix.runner_print_label != 'SKIP'
         run: |
           sudo apt-get install -y --no-install-recommends libcairo2-dev libgirepository1.0-dev
           python3 -m venv --system-site-packages $HOME/optimizer-venv
-          $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/scripts/optimizer/requirements.txt
+          $HOME/optimizer-venv/bin/pip install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt
           echo "$HOME/optimizer-venv/bin" >> $GITHUB_PATH
 
-      - name: Run Optimizer on host
+      - name: 🚀 Run Optimizer on host
         if: always() && matrix.runner_print_label != 'SKIP'
         id: run_optimizer_on_host
         env:

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -326,7 +326,7 @@ jobs:
             /MB$/ { printf "%d", $1; next }
             /kB$/ { printf "0"; next }
           ')
-          echo "Actual image size : ${IMAGE_SIZE_MB} MB"
+          echo "Actual image size (docker images SIZE): ${SIZE_STR} (~${IMAGE_SIZE_MB} MB)"
           echo "Expected size: ${EXPECTED_SIZE_MB} MB"
           DIFF=$(( IMAGE_SIZE_MB - EXPECTED_SIZE_MB ))
           ABS_DIFF=${DIFF#-}

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -527,9 +527,9 @@ COPY --from=rpm-builder /rpms/*.rpm /rpms/
 
 # Download and install DLS rpm package
 RUN \
-    dnf install -y /rpms/*.rpm cairo-devel gobject-introspection-devel && \
+    dnf install -y /rpms/*.rpm cairo-devel cairo-gobject-devel gobject-introspection-devel && \
     pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
-    dnf remove -y cairo-devel gobject-introspection-devel && \
+    dnf remove -y cairo-devel cairo-gobject-devel gobject-introspection-devel && \
     dnf clean all && \
     useradd -ms /bin/bash dlstreamer && \
     chown -R dlstreamer: /opt && \

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -528,7 +528,7 @@ COPY --from=rpm-builder /rpms/*.rpm /rpms/
 # Download and install DLS rpm package
 RUN \
     dnf install -y /rpms/*.rpm cairo-devel cairo-gobject-devel gobject-introspection-devel && \
-    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
     dnf remove -y cairo-devel cairo-gobject-devel gobject-introspection-devel && \
     dnf clean all && \
     useradd -ms /bin/bash dlstreamer && \

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -527,9 +527,10 @@ COPY --from=rpm-builder /rpms/*.rpm /rpms/
 
 # Download and install DLS rpm package
 RUN \
-    dnf install -y /rpms/*.rpm && \
-    dnf clean all && \
+    dnf install -y /rpms/*.rpm cairo-devel gobject-introspection-devel && \
     pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
+    dnf remove -y cairo-devel gobject-introspection-devel && \
+    dnf clean all && \
     useradd -ms /bin/bash dlstreamer && \
     chown -R dlstreamer: /opt && \
     chmod -R u+rw /opt

--- a/docker/fedora41/fedora41.Dockerfile
+++ b/docker/fedora41/fedora41.Dockerfile
@@ -400,8 +400,6 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
-RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt"
-
 WORKDIR $DLSTREAMER_DIR/build
 
 # DLStreamer environment variables
@@ -474,6 +472,7 @@ RUN \
     cp -r "${DLSTREAMER_DIR}/scripts/" /${RPM_PKG_NAME}/opt/intel/dlstreamer/ && \
     cp -r "${DLSTREAMER_DIR}/include/" /${RPM_PKG_NAME}/opt/intel/dlstreamer/ && \
     cp "${DLSTREAMER_DIR}/README.md" /${RPM_PKG_NAME}/opt/intel/dlstreamer && \
+    cp "${DLSTREAMER_DIR}/requirements.txt" /${RPM_PKG_NAME}/opt/intel/dlstreamer && \
     cp -rT "${GSTREAMER_DIR}" /${RPM_PKG_NAME}/opt/intel/dlstreamer/gstreamer && \
     mkdir -p /${RPM_PKG_NAME}/opt/intel/dlstreamer/share/gir-1.0/ && \
     mkdir -p /${RPM_PKG_NAME}/opt/intel/dlstreamer/lib/girepository-1.0/ && \
@@ -530,6 +529,7 @@ COPY --from=rpm-builder /rpms/*.rpm /rpms/
 RUN \
     dnf install -y /rpms/*.rpm && \
     dnf clean all && \
+    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
     useradd -ms /bin/bash dlstreamer && \
     chown -R dlstreamer: /opt && \
     chmod -R u+rw /opt

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -549,9 +549,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update -y && \
-    apt-get install -y -q --no-install-recommends /debs/*.deb && \
-    apt-get clean -y && \
+    apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
     pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
+    apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
+    apt-get autoremove -y && \
+    apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f /*.deb && \
     useradd -ms /bin/bash dlstreamer && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -550,7 +550,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
-    pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --break-system-packages --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
     apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \
     apt-get clean -y && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -551,7 +551,7 @@ RUN \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends /debs/*.deb && \
     apt-get clean -y && \
-    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f /*.deb && \
     useradd -ms /bin/bash dlstreamer && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -394,8 +394,7 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
-RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt" && \
-    mkdir build
+RUN mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build
 
@@ -461,6 +460,7 @@ RUN \
     cp -r "${DLSTREAMER_DIR}/scripts/" /deb-pkg/opt/intel/dlstreamer/ && \
     cp -r "${DLSTREAMER_DIR}/include/" /deb-pkg/opt/intel/dlstreamer/ && \
     cp "${DLSTREAMER_DIR}/README.md" /deb-pkg/opt/intel/dlstreamer && \
+    cp "${DLSTREAMER_DIR}/requirements.txt" /deb-pkg/opt/intel/dlstreamer && \
     cp -rT "${GSTREAMER_DIR}" /deb-pkg/opt/intel/dlstreamer/gstreamer && \
     mkdir -p /deb-pkg/opt/intel/dlstreamer/lib/girepository-1.0 && \
     mkdir -p /deb-pkg/opt/intel/dlstreamer/share/gir-1.0 && \
@@ -551,6 +551,7 @@ RUN \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends /debs/*.deb && \
     apt-get clean -y && \
+    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
     rm -rf /var/lib/apt/lists/* && \
     rm -f /*.deb && \
     useradd -ms /bin/bash dlstreamer && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -549,9 +549,10 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update -y && \
-    apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* meson=\* ninja-build=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
+    apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* ninja-build=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
+    pip3 install --no-cache-dir meson && \
     pip3 install --no-cache-dir --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
-    apt-get remove -y gcc meson ninja-build libcairo2-dev libgirepository1.0-dev && \
+    apt-get remove -y gcc ninja-build libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -550,7 +550,8 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* ninja-build=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
-    pip3 install --no-cache-dir meson && \
+    pip3 install --no-cache-dir pip==25.3 setuptools==78.1.1 wheel==0.45.1 packaging==24.2 && \
+    pip3 install --no-cache-dir meson==1.6.1 && \
     pip3 install --no-cache-dir --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
     apt-get remove -y gcc ninja-build libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -549,9 +549,9 @@ ARG DEBIAN_FRONTEND=noninteractive
 
 RUN \
     apt-get update -y && \
-    apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
+    apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* meson=\* ninja-build=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
     pip3 install --no-cache-dir --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
-    apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
+    apt-get remove -y gcc meson ninja-build libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \
     apt-get clean -y && \
     rm -rf /var/lib/apt/lists/* && \

--- a/docker/ubuntu/ubuntu22.Dockerfile
+++ b/docker/ubuntu/ubuntu22.Dockerfile
@@ -550,7 +550,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN \
     apt-get update -y && \
     apt-get install -y -q --no-install-recommends /debs/*.deb gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
-    pip3 install --no-cache-dir --break-system-packages --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
     apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \
     apt-get clean -y && \

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -577,7 +577,7 @@ RUN \
     apt-get update && \
     apt-get install -y -q --no-install-recommends python3-pip=\* && \
     pip3 install --no-cache-dir --break-system-packages onvif-zeep==0.2.12 && \
-    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
     cp -r /usr/local/lib/python3.12/site-packages/wsdl /usr/local/lib/python3.12/dist-packages/ && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -577,7 +577,7 @@ RUN \
     apt-get update && \
     apt-get install -y -q --no-install-recommends python3-pip=\* gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
     pip3 install --no-cache-dir --break-system-packages onvif-zeep==0.2.12 && \
-    pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
+    pip3 install --no-cache-dir --break-system-packages --ignore-installed -r /opt/intel/dlstreamer/requirements.txt && \
     apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
     apt-get autoremove -y && \
     cp -r /usr/local/lib/python3.12/site-packages/wsdl /usr/local/lib/python3.12/dist-packages/ && \

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -575,9 +575,11 @@ RUN \
 # Install onvif-zeep Python package
 RUN \
     apt-get update && \
-    apt-get install -y -q --no-install-recommends python3-pip=\* && \
+    apt-get install -y -q --no-install-recommends python3-pip=\* gcc=\* libcairo2-dev=\* libgirepository1.0-dev=\* && \
     pip3 install --no-cache-dir --break-system-packages onvif-zeep==0.2.12 && \
     pip3 install --no-cache-dir --break-system-packages -r /opt/intel/dlstreamer/requirements.txt && \
+    apt-get remove -y gcc libcairo2-dev libgirepository1.0-dev && \
+    apt-get autoremove -y && \
     cp -r /usr/local/lib/python3.12/site-packages/wsdl /usr/local/lib/python3.12/dist-packages/ && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/docker/ubuntu/ubuntu24.Dockerfile
+++ b/docker/ubuntu/ubuntu24.Dockerfile
@@ -403,8 +403,7 @@ WORKDIR "$DLSTREAMER_DIR"
 
 COPY . "${DLSTREAMER_DIR}"
 
-RUN /python3venv/bin/pip3 install --no-cache-dir -r "${DLSTREAMER_DIR}/scripts/optimizer/requirements.txt" && \
-    mkdir build
+RUN mkdir build
 
 WORKDIR $DLSTREAMER_DIR/build
 
@@ -474,6 +473,7 @@ RUN \
     cp -r "${DLSTREAMER_DIR}/scripts/" /deb-pkg/opt/intel/dlstreamer/ && \
     cp -r "${DLSTREAMER_DIR}/include/" /deb-pkg/opt/intel/dlstreamer/ && \
     cp "${DLSTREAMER_DIR}/README.md" /deb-pkg/opt/intel/dlstreamer && \
+    cp "${DLSTREAMER_DIR}/requirements.txt" /deb-pkg/opt/intel/dlstreamer && \
     cp -rT "${GSTREAMER_DIR}" /deb-pkg/opt/intel/dlstreamer/gstreamer && \
     mkdir -p /deb-pkg/opt/intel/dlstreamer/lib/girepository-1.0 && \
     mkdir -p /deb-pkg/opt/intel/dlstreamer/share/gir-1.0 && \
@@ -577,6 +577,7 @@ RUN \
     apt-get update && \
     apt-get install -y -q --no-install-recommends python3-pip=\* && \
     pip3 install --no-cache-dir --break-system-packages onvif-zeep==0.2.12 && \
+    pip3 install --no-cache-dir -r /opt/intel/dlstreamer/requirements.txt && \
     cp -r /usr/local/lib/python3.12/site-packages/wsdl /usr/local/lib/python3.12/dist-packages/ && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Description

Replace references to scripts/optimizer/requirements.txt with the repository root requirements.txt across CI and Dockerfiles. Update the workflow step name (Install requirements on host) and the Run Optimizer step label. Remove early-stage pip installs of optimizer requirements in the Fedora/Ubuntu build stages, copy requirements.txt into the packaged image, and install dependencies in the final image layer (pip3 install -r /opt/intel/dlstreamer/requirements.txt). This centralizes dependency management and ensures runtime requirements are present in the built containers and CI venv.

New/current expected docker images sizes:

- Ubuntu 22 dev: 7300 MB
- Ubuntu 22 deb: 3250 MB
- Ubuntu 24 dev: 7700 MB
- Ubuntu 24 deb: 3250 MB

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

