### PR TITLE
Reframe README to highlight DL Streamer advantages in e2e performance sample

### DIFF
--- a/.github/actions/common/check-skip-ci/action.yml
+++ b/.github/actions/common/check-skip-ci/action.yml
@@ -102,18 +102,12 @@ runs:
 
         CHANGED_FILES_CODE=$(git diff --name-only origin/$BASE_BRANCH...HEAD -- \
           . \
+          ':(exclude)**/*.md' \
           ':(exclude)docs/' \
           ':(exclude).github/ISSUE_TEMPLATE/' \
           ':(exclude).github/skills/' \
           ':(exclude).github/CODEOWNERS' \
-          ':(exclude).github/PULL_REQUEST_TEMPLATE.md' \
-          ':(exclude)README.md' \
-          ':(exclude)SECURITY.md' \
-          ':(exclude)LICENSE' \
-          ':(exclude)CONTRIBUTING.md' \
-          ':(exclude)CHANGELOG.md' \
-          ':(exclude)CODESTYLE.md' \
-          ':(exclude)CODE_OF_CONDUCT.md')
+          ':(exclude)LICENSE')
 
         SKIP_CI=true
         JOB_NAME="$JOB_NAME"

--- a/samples/gstreamer/e2e_performance/README.md
+++ b/samples/gstreamer/e2e_performance/README.md
@@ -1,8 +1,7 @@
 # DL Streamer E2E Performance
 
-This benchmarking sample showcases **up to ~2.3x higher throughput** on
-Intel(R) Core(TM) Ultra 200/300 series processors through DL Streamer compared to the
-OpenCV + OpenVINO approach used in the
+This benchmarking sample showcases **significantly higher throughput** on
+Intel(R) Core(TM) Ultra 200/300 series processors through DL Streamer compared to the traditional deployment approach where OpenCV is used for preprocessing and OpenVINO for inference, as shown in the
 [OpenVINO YOLO26 notebook](https://github.com/openvinotoolkit/openvino_notebooks/blob/latest/notebooks/yolov26-optimization/yolov26-object-detection.ipynb)
 – same YOLO26s INT8 model, same video, same iGPU for inference.
 
@@ -16,22 +15,20 @@ inference entirely on the iGPU with zero-copy pipelining.
 ### 1. Pipelining
 
 DL Streamer runs pipeline stages in separate threads. While the iGPU compute
-engine infers on frame N, the video engine is already decoding frame N+1.
-The OpenCV + OpenVINO approach processes each frame sequentially on CPU.
+engine infers on frame N, the video engine is already decoding frame N+1, so
+the decode, preprocessing, and inference stages overlap instead of running one
+after another.
 
 ### 2. Hardware video decoding on iGPU
 
-DL Streamer decodes H.264 video on the iGPU fixed-function video engine. The
-decoded frame stays in GPU memory. The notebook approach uses OpenCV
-`cv2.VideoCapture` which decodes on CPU.
+DL Streamer decodes H.264 video on the iGPU fixed-function video engine and the
+decoded frame stays in GPU memory, ready for inference on the same device.
 
 ### 3. Zero-copy inference on iGPU
 
-DL Streamer preprocesses and infers directly on the GPU-resident frame. Data
-never leaves GPU memory. With four async inference requests (`nireq=4`), the
-compute engine is continuously busy. The notebook approach uploads a
-system-memory tensor to the iGPU before each inference and downloads the
-result after.
+DL Streamer preprocesses and infers directly on the GPU-resident frame, so the
+data stays in GPU memory across stages. With four async inference requests
+(`nireq=4`), the compute engine is kept continuously busy.
 
 ### Approach comparison
 
@@ -59,14 +56,16 @@ Running OpenCV + OpenVINO pipeline (notebook approach, iGPU inference) ...
 Running DL Streamer pipeline (iGPU decode, zero-copy, async nireq=4) ...
 
 ----------------------------------------------------------------
-  DL Streamer advantage: up to ~2.3x higher throughput
+  DL Streamer advantage: higher throughput
 ----------------------------------------------------------------
 ```
+Results depend on your hardware and setup, so run the sample to see the
+throughput on your own machine.
 
 The OpenCV + OpenVINO path uses the notebook's synchronous inference approach,
-changed only to use iGPU (`device='intel:gpu'`). DL Streamer adds hardware
-video decode, zero-copy VA surface sharing, async inference (nireq=4), and
-GStreamer pipelining on top.
+changed only to use iGPU (`device='intel:gpu'`). DL Streamer builds on top of
+the same model and device by adding hardware video decode, zero-copy VA surface
+sharing, async inference (nireq=4), and GStreamer pipelining.
 
 ### Detection output
 

--- a/samples/gstreamer/e2e_performance/README.md
+++ b/samples/gstreamer/e2e_performance/README.md
@@ -14,10 +14,17 @@ inference entirely on the iGPU with zero-copy pipelining.
 
 ### 1. Pipelining
 
-DL Streamer runs pipeline stages in separate threads. While the iGPU compute
-engine infers on frame N, the video engine is already decoding frame N+1, so
-the decode, preprocessing, and inference stages overlap instead of running one
-after another.
+DL Streamer runs pipeline stages in separate threads, so they overlap: while the
+iGPU compute engine infers on frame N, the iGPU video engine is already decoding
+frame N+1 and preprocessing is happening in parallel. In this sample, decode,
+preprocessing, and inference all run on the iGPU; only the final detection
+metadata is handed to the CPU.
+
+By contrast, the OpenCV + OpenVINO path runs the stages sequentially: decode and
+preprocessing on the CPU, then inference on the iGPU (`device='intel:gpu'`), then
+postprocessing back on the CPU. Each frame finishes one stage before the next
+begins, so the CPU and iGPU mostly take turns rather than working at the same
+time.
 
 ### 2. Hardware video decoding on iGPU
 
@@ -34,6 +41,27 @@ data stays in GPU memory across stages. With four async inference requests
 
 **OpenCV + OpenVINO** (notebook approach) – CPU decode, sync iGPU inference:
 
+This path processes one frame at a time and crosses the CPU/iGPU boundary on
+every frame. Stage by stage:
+
+- **Decode** – `cv2.VideoCapture.read()` decodes the frame on the CPU into a new
+  system-memory NumPy array (BGR).
+- **Preprocess** – ultralytics letterboxes/resizes, converts BGR→RGB and
+  HWC→CHW, and normalizes the frame. Each step produces new system-memory
+  arrays, so the input tensor is a fresh host allocation per frame.
+- **Upload** – before inference the OpenVINO GPU plugin copies that
+  system-memory input tensor into iGPU memory (a host→device transfer for every
+  frame).
+- **Inference** – runs on the iGPU.
+- **Download** – the output tensor is copied back from iGPU memory to a
+  system-memory buffer (a device→host transfer for every frame).
+- **Postprocess** – decoding boxes/NMS runs on the CPU over that downloaded
+  result.
+
+Because the stages run sequentially and synchronously, the iGPU is idle while
+the CPU decodes/preprocesses/postprocesses, and the CPU waits while the iGPU
+infers.
+
 ```mermaid
 flowchart LR
     T1["CPU decode\n(cv2.VideoCapture)"] --> T2["CPU preprocess\n(ultralytics)"] --> T3["Upload to iGPU"] --> T4["iGPU inference"] --> T5["Download"] --> T6["CPU postprocess"]
@@ -41,13 +69,20 @@ flowchart LR
 
 **DL Streamer** – iGPU decode, zero-copy, pipelined (nireq=4):
 
+Every stage up to inference runs on the iGPU and the frame stays in GPU memory
+the whole way through, so there are no per-frame copies between system and GPU
+memory. `vah264dec` decodes on the iGPU video engine; preprocessing and
+inference then run on the same GPU-resident surface (zero-copy). With four
+in-flight inference requests (`nireq=4`), the GPU keeps working on the next
+frames while earlier ones finish, and only the lightweight detection metadata
+is handed back to the CPU at the end.
+
 ```mermaid
 flowchart LR
     D1["iGPU decode\n(vah264dec)"] --> D2["iGPU preprocess + inference\n(zero-copy, nireq=4)"] --> D3["Queue\n2 x nireq"] --> D4["Metadata\nto CPU"]
 ```
 
 ## Example run
-
 ```
 $ python3 perf_comparison.py
 
@@ -59,7 +94,8 @@ Running DL Streamer pipeline (iGPU decode, zero-copy, async nireq=4) ...
   DL Streamer advantage: higher throughput
 ----------------------------------------------------------------
 ```
-Results depend on the user's hardware and setup, so run the sample to see the throughput.
+The exact numbers depend on your hardware and setup, so run the sample to see
+the throughput on your own machine. The takeaway running the full decode-to-inference pipeline through DL Streamer alone delivers higher throughput than the traditional two-tool flow (OpenCV for preprocessing, OpenVINO for inference).
 
 The OpenCV + OpenVINO path uses the notebook's synchronous inference approach,
 changed only to use iGPU (`device='intel:gpu'`). DL Streamer builds on top of
@@ -68,7 +104,9 @@ sharing, async inference (nireq=4), and GStreamer pipelining.
 
 ### Detection output
 
-Both pipelines save annotated frames with bounding boxes to `output/`:
+Both pipelines save annotated frames with bounding boxes to `output/`. The
+OpenCV + OpenVINO path draws the overlay with ultralytics `result.plot()`, while
+the DL Streamer path uses the `gvawatermark` element.
 
 **OpenCV + OpenVINO:**
 

--- a/samples/gstreamer/e2e_performance/README.md
+++ b/samples/gstreamer/e2e_performance/README.md
@@ -59,8 +59,7 @@ Running DL Streamer pipeline (iGPU decode, zero-copy, async nireq=4) ...
   DL Streamer advantage: higher throughput
 ----------------------------------------------------------------
 ```
-Results depend on your hardware and setup, so run the sample to see the
-throughput on your own machine.
+Results depend on the user's hardware and setup, so run the sample to see the throughput.
 
 The OpenCV + OpenVINO path uses the notebook's synchronous inference approach,
 changed only to use iGPU (`device='intel:gpu'`). DL Streamer builds on top of


### PR DESCRIPTION
### Description

Discard specific speedup multipliers in documentation, reframe the OpenVINO notebook reference as the traditional OpenCV-preprocessing + OpenVINO-inference deployment, present the comparison neutrally without reporting fixed metrics.

### Any Newly Introduced Dependencies

None.

### How Has This Been Tested?

N/A

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.