### PR TITLE
update gvawatermark documentation to reflect kernel size dynamics

### DIFF
--- a/docs/user-guide/elements/gvawatermark.md
+++ b/docs/user-guide/elements/gvawatermark.md
@@ -189,7 +189,8 @@ e.g `displ-cfg=show-labels=true,hide-roi=car`
 
 ### Blur Feature
 
-The gvawatermark element supports privacy protection through region of interest (ROI) blurring using OpenCV GaussianBlur with a 15x15 kernel. This feature is useful for anonymizing faces, license plates, or other sensitive content in video streams.
+The gvawatermark element supports privacy protection through region of interest (ROI) blurring using OpenCV GaussianBlur with a dynamic kernel size as ~1/5 of each ROI dimension (minimum 7, always odd)
+so the blur strength scales with the region. This feature is useful for anonymizing faces, license plates, or other sensitive content in video streams.
 
 #### Blur Configuration Parameters
 


### PR DESCRIPTION

### Description

update gvawatermark documentation to reflect kernel size dynamics to depict that kernel size is ~1/5 of each ROI dimension.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

