### PR TITLE
DeepStream conversion: add links to auto-generated conversion samples

### DIFF
--- a/docs/user-guide/dev_guide/converting_deepstream_to_dlstreamer.md
+++ b/docs/user-guide/dev_guide/converting_deepstream_to_dlstreamer.md
@@ -486,6 +486,8 @@ configuration properties to Deep Learning Streamer settings.
 ## AI-Supported Conversions
 In addition to the detailed description of the conversion rules between DeepStream and Deep Learning Streamer applications presented above, we also provide the ability to perform such conversions automatically using a coding agent. As part of the [DL Streamer](https://github.com/open-edge-platform/dlstreamer) project, guidelines for the coding agent have been prepared to support conversion of applications written in **Python**; see [deepstream-python-conversion](https://github.com/open-edge-platform/dlstreamer/tree/main/.github/skills/dlstreamer-coding-agent/examples/deepstream-python-conversion.md). They also support conversion of **C/C++** applications; see [deepstream-cpp-conversion](https://github.com/open-edge-platform/dlstreamer/tree/main/.github/skills/dlstreamer-coding-agent/examples/deepstream-cpp-conversion.md).
 
+To see examples of DeepStream applications automatically converted by the coding agent, refer to the [auto_generated_samples](../../../samples/auto_generated_samples/) directory, which includes [Python](../../../samples/auto_generated_samples/deepstream_python_conversion/) and [C++](../../../samples/auto_generated_samples/deepstream_cpp_conversion/) conversion examples.
+
 ### Supported Languages
 
 The coding agent supports conversion of DeepStream applications developed in the following programming languages:


### PR DESCRIPTION
### Description
Update docs/user-guide/dev_guide/converting_deepstream_to_dlstreamer.md to reference the samples/auto_generated_samples directory. This adds direct links to Python and C++ examples demonstrating DeepStream applications automatically converted by the coding agent, making it easier for users to find and review conversion outputs.

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

