### PR TITLE
[DOCS] Add explicit branch checkout - 2026.1

### DIFF
--- a/docs/user-guide/dev_guide/advanced_install/advanced_build_docker_image.md
+++ b/docs/user-guide/dev_guide/advanced_install/advanced_build_docker_image.md
@@ -14,7 +14,7 @@ Follow the instructions in
 ## Step 2: Clone DL Streamer repository
 
 ```bash
-git clone https://github.com/open-edge-platform/dlstreamer.git
+git clone https://github.com/open-edge-platform/dlstreamer.git -b v2026.1.0
 cd dlstreamer
 git submodule update --init --recursive
 ```

--- a/docs/user-guide/dev_guide/advanced_install/advanced_install_guide_compilation.md
+++ b/docs/user-guide/dev_guide/advanced_install/advanced_install_guide_compilation.md
@@ -97,7 +97,7 @@ packages:
 
   ```bash
   cd ~
-  git clone --recursive https://github.com/open-edge-platform/dlstreamer.git
+  git clone --branch v2026.1.0 --recursive https://github.com/open-edge-platform/dlstreamer.git
   cd dlstreamer
   ```
 

--- a/docs/user-guide/dev_guide/advanced_install/advanced_install_guide_windows_compilation.md
+++ b/docs/user-guide/dev_guide/advanced_install/advanced_install_guide_windows_compilation.md
@@ -8,7 +8,7 @@ from the source code provided in
 ## Step 1: Clone Deep Learning Streamer repository
 
 ```bash
-git clone --recursive https://github.com/open-edge-platform/dlstreamer.git
+git clone --branch v2026.1.0 --recursive https://github.com/open-edge-platform/dlstreamer.git
 cd dlstreamer
 git submodule update --init --recursive
 ```

--- a/docs/user-guide/get_started/install/install_guide_ubuntu.md
+++ b/docs/user-guide/get_started/install/install_guide_ubuntu.md
@@ -26,7 +26,7 @@ resources when additional configuration is required.
 ```bash
 mkdir -p ~/intel/dlstreamer_gst
 cd ~/intel/dlstreamer_gst/
-wget -O DLS_install_prerequisites.sh https://raw.githubusercontent.com/open-edge-platform/dlstreamer/main/scripts/DLS_install_prerequisites.sh && chmod +x DLS_install_prerequisites.sh
+wget -O DLS_install_prerequisites.sh https://raw.githubusercontent.com/open-edge-platform/dlstreamer/v2026.1.0/scripts/DLS_install_prerequisites.sh && chmod +x DLS_install_prerequisites.sh
 ```
 
 ### Step 2: Execute the script and follow its instructions


### PR DESCRIPTION
### Description

- add explicit branch checkout (to `v2026.1.0` tag) to git clone commands
- update one script with the `v2026.1.0` tag

Partial port from: #916.

### How Has This Been Tested?

### Checklist:

- [X] I agree to use the MIT license for my code changes.
- [X] I have not introduced any 3rd party components incompatible with MIT. 
- [X] I have not included any company confidential information, trade secret, password or security token. 
- [X] I have performed a self-review of my code.