### PR TITLE
Align OpenVINO export-requirements.txt for GenAI to 2026/0

### DIFF
--- a/samples/gstreamer/gst_launch/gvagenai/README.md
+++ b/samples/gstreamer/gst_launch/gvagenai/README.md
@@ -23,7 +23,7 @@ This sample builds GStreamer pipeline of the following elements:
 
 > [!NOTE]
 > To install `optimum-cli` and other required dependencies for model export, refer to the respective OpenVINO™ notebook tutorials linked in the table below.
-> DL Streamer currently depends on OpenVINO™ GenAI 2026.1.0. For optimal compatibility, use the library versions specified in [export-requirements.txt](https://github.com/openvinotoolkit/openvino.genai/blob/releases/2026/1/samples/export-requirements.txt).
+> DL Streamer currently depends on OpenVINO™ GenAI 2026.0.0. For optimal compatibility, use the library versions specified in [export-requirements.txt](https://github.com/openvinotoolkit/openvino.genai/blob/releases/2026/0/samples/export-requirements.txt).
 
 | Model | Export Command | Tutorial |
 |-------|----------------|----------|

--- a/samples/gstreamer/python/onvif_camera_analytics_validation/README.md
+++ b/samples/gstreamer/python/onvif_camera_analytics_validation/README.md
@@ -80,7 +80,7 @@ export MODELS_PATH="$HOME/models"
 cd /opt/intel/dlstreamer/scripts/download_models
 python3 -m venv .model_download_venv
 source .model_download_venv/bin/activate
-curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/1/samples/export-requirements.txt
+curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/0/samples/export-requirements.txt
 pip install -r export-requirements.txt -r requirements.txt
 
 python download_hf_models.py \

--- a/scripts/download_models/README.md
+++ b/scripts/download_models/README.md
@@ -17,7 +17,7 @@ This folder contains standalone conversion CLIs:
 
 2. Install dependencies:
 ```code
-   curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/1/samples/export-requirements.txt
+   curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/0/samples/export-requirements.txt
    pip install -r export-requirements.txt -r requirements.txt
    ```
 


### PR DESCRIPTION
### Description
Replace references to OpenVINO GenAI 2026.1.0 and update export-requirements URLs from releases/2026/1 to releases/2026/0. Affected files: samples/gstreamer/gst_launch/gvagenai/README.md, samples/gstreamer/python/onvif_camera_analytics_validation/README.md, and scripts/download_models/README.md. This aligns DL Streamer docs and model-download instructions with the 2026.0.0 release for compatibility when exporting models.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

