### PR TITLE
Models downloading scripts: handle exported model files and CLI exit

### DIFF
--- a/scripts/download_models/download_timm_models.py
+++ b/scripts/download_models/download_timm_models.py
@@ -184,7 +184,12 @@ def save_ir(exported_xml: Path, xml: Path) -> None:
         ov.Core().read_model(str(tmp_xml))
         tmp_bin.replace(xml.with_suffix(".bin"))
         tmp_xml.replace(xml)
+    skip = {exported_xml.name, exported_xml.with_suffix(".bin").name}
+    for companion in exported_xml.parent.iterdir():
+        if companion.name not in skip and companion.is_file():
+            shutil.copy2(companion, xml.parent / companion.name)
 
 
-cli_args = parse_args()
-cli_args.func(cli_args)
+if __name__ == "__main__":
+    _args = parse_args()
+    raise SystemExit(_args.func(_args))

--- a/scripts/download_models/download_ultralytics_models.py
+++ b/scripts/download_models/download_ultralytics_models.py
@@ -69,9 +69,10 @@ def is_explicit_local_model_path(model_or_path: str) -> bool:
 
 
 def move_exported_model(exported_path: Path, outdir: Path) -> Path:
-    desired_path = outdir / exported_path.name
-    exported_path.rename(desired_path)
-    return desired_path
+    for item in exported_path.iterdir():
+        item.rename(outdir / item.name)
+    exported_path.rmdir()
+    return outdir
 
 
 def main() -> int:

--- a/scripts/download_models/hf_utils.py
+++ b/scripts/download_models/hf_utils.py
@@ -253,7 +253,6 @@ def export_hf_rtdetr_to_openvino(
     """
     outdir.mkdir(parents=True, exist_ok=True)
     _ = extra_args
-    model_onnx = outdir / "model.onnx"
 
     main_export(
         model_id,
@@ -265,6 +264,11 @@ def export_hf_rtdetr_to_openvino(
         height=640,
         auth_token=token,
     )
+
+    onnx_files = list(outdir.glob("*.onnx"))
+    if not onnx_files:
+        raise FileNotFoundError(f"main_export produced no .onnx files in {outdir}")
+    model_onnx = onnx_files[0]
 
     hf_hub_download(
         repo_id=model_id,


### PR DESCRIPTION
### Description

Copy and move additional exported model artifacts and make ONNX detection more robust.
- download_timm_models.py: copy companion files from the exporter output directory into the target XML directory (skipping the main exported XML and its .bin). Add a proper if __name__ == "__main__" guard and raise SystemExit with the CLI return value.
- download_ultralytics_models.py: change move_exported_model to move individual items from the exported directory into the output directory and remove the now-empty source directory (instead of renaming the whole directory).
- hf_utils.py: no longer assume a fixed model.onnx name; search the output dir for produced .onnx files, use the first found, and raise a FileNotFoundError if none are produced.

These changes improve handling of exporter outputs (extra files and variable ONNX names) and make the CLI exit behavior explicit.

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

