### PR TITLE
[INFERENCE] reduce lock contention in multi-stream shared inference

### DIFF
--- a/src/monolithic/gst/inference_elements/base/inference_impl.cpp
+++ b/src/monolithic/gst/inference_elements/base/inference_impl.cpp
@@ -38,6 +38,7 @@
 #include <openvino/runtime/core.hpp>
 #include <openvino/runtime/properties.hpp>
 #include <regex>
+#include <shared_mutex>
 #include <sstream>
 #include <string>
 #include <thread>
@@ -1003,8 +1004,8 @@ void InferenceImpl::FlushOutputs() {
 }
 
 void InferenceImpl::UpdateObjectClasses(const gchar *obj_classes_str) {
-    // Lock mutex to avoid data race in case of shared inference instance in multichannel mode
-    std::unique_lock<std::mutex> lock(_mutex);
+    // Exclusive lock to avoid data race in case of shared inference instance in multichannel mode
+    std::unique_lock<std::shared_mutex> lock(_mutex);
 
     if (obj_classes_str && obj_classes_str[0])
         object_classes = Utils::splitString(obj_classes_str, ',');
@@ -1036,6 +1037,7 @@ void InferenceImpl::UpdateModelReshapeInfo(GvaBaseInference *gva_base_inference)
 }
 
 bool InferenceImpl::FilterObjectClass(GstVideoRegionOfInterestMeta *roi) const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
     if (object_classes.empty())
         return true;
     auto compare_quark_string = [roi](const std::string &str) {
@@ -1046,6 +1048,7 @@ bool InferenceImpl::FilterObjectClass(GstVideoRegionOfInterestMeta *roi) const {
 }
 
 bool InferenceImpl::FilterObjectClass(GstAnalyticsODMtd roi) const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
     if (object_classes.empty())
         return true;
     auto compare_quark_string = [roi](const std::string &str) {
@@ -1057,6 +1060,7 @@ bool InferenceImpl::FilterObjectClass(GstAnalyticsODMtd roi) const {
 }
 
 bool InferenceImpl::FilterObjectClass(const std::string &object_class) const {
+    std::shared_lock<std::shared_mutex> lock(_mutex);
     if (object_classes.empty())
         return true;
     return std::find(object_classes.cbegin(), object_classes.cend(), object_class) != object_classes.cend();
@@ -1144,56 +1148,93 @@ void InferenceImpl::SetAffinityMask(const WinCorePinningMask &mask) {
 
 /**
  * Acquires output_frames_mutex with std::lock_guard.
+ * Push completed inference frames downstream.
+ *
+ * Design: frames are collected while holding output_frames_mutex, then pushed
+ * downstream after releasing the lock. This prevents gst_pad_push (which may
+ * block) from starving other streaming threads that insert into output_frames.
+ *
+ * Per-stream ordering is preserved: if any frame for a given stream is still
+ * pending inference, all later frames for that stream are held back. However,
+ * completed frames from OTHER streams are pushed through (reducing HOL blocking
+ * across streams compared to the original break-on-first-pending approach).
  */
 void InferenceImpl::PushOutput() {
     ITT_TASK(__FUNCTION__);
-    std::lock_guard<std::mutex> guard(output_frames_mutex);
 
-    // track output queues that are full
-    std::map<std::string, bool> output_full;
+    // Collect frames to push while holding the lock, then push them outside the lock.
+    // PushBufferToSrcPad calls gst_pad_push which may block downstream.
+    // Holding output_frames_mutex during that call starves other streaming threads
+    // that need to push into output_frames in TransformFrameIp.
+    std::vector<OutputFrame> frames_to_push;
 
-    auto frame = output_frames.begin();
-    while (frame != output_frames.end()) {
-        if ((*frame).inference_count != 0) {
-            break; // inference not completed yet
-        }
+    {
+        std::lock_guard<std::mutex> guard(output_frames_mutex);
 
-        for (const std::shared_ptr<InferenceFrame> &inference_roi : (*frame).inference_rois) {
-            gint meta_id = 0;
-            if (inference_roi->roi.id >= 0) {
-                GMutexLockGuard guard(&inference_roi->gva_base_inference->meta_mutex);
-                GstAnalyticsRelationMeta *relation_meta = gst_buffer_get_analytics_relation_meta(inference_roi->buffer);
-                if (!relation_meta) {
-                    throw std::runtime_error("Failed to find relation meta");
-                }
+        // track output queues that are full
+        std::map<std::string, bool> output_full;
 
-                GstAnalyticsODMtd od_mtd;
-                if (!gst_analytics_relation_meta_get_od_mtd(relation_meta, inference_roi->roi.id, &od_mtd)) {
-                    throw std::runtime_error("Failed to find od metadata");
-                }
+        auto frame = output_frames.begin();
+        while (frame != output_frames.end()) {
+            GstObject *src = &(*frame).filter->base_transform.element.object;
 
-                if (!post_processing::sameRegion(&od_mtd, &inference_roi->roi)) {
-                    throw std::runtime_error("Roi and od meta are not the same region");
-                }
-
-                get_od_id(od_mtd, &meta_id);
+            if ((*frame).inference_count != 0) {
+                // Inference not completed yet for this frame.
+                // Mark this stream as blocked so its later frames maintain ordering,
+                // but continue iterating to push completed frames from other streams.
+                output_full[src->name] = true;
+                frame++;
+                continue;
             }
 
-            for (const GstStructure *roi_classification : inference_roi->roi_classifications) {
-                UpdateClassificationHistory(meta_id, (*frame).filter, roi_classification);
+            if (output_full[src->name]) {
+                // A prior frame for this stream is still pending — skip to preserve ordering
+                frame++;
+                continue;
+            }
+
+            for (const std::shared_ptr<InferenceFrame> &inference_roi : (*frame).inference_rois) {
+                gint meta_id = 0;
+                if (inference_roi->roi.id >= 0) {
+                    GMutexLockGuard guard(&inference_roi->gva_base_inference->meta_mutex);
+                    GstAnalyticsRelationMeta *relation_meta =
+                        gst_buffer_get_analytics_relation_meta(inference_roi->buffer);
+                    if (!relation_meta) {
+                        throw std::runtime_error("Failed to find relation meta");
+                    }
+
+                    GstAnalyticsODMtd od_mtd;
+                    if (!gst_analytics_relation_meta_get_od_mtd(relation_meta, inference_roi->roi.id, &od_mtd)) {
+                        throw std::runtime_error("Failed to find od metadata");
+                    }
+
+                    if (!post_processing::sameRegion(&od_mtd, &inference_roi->roi)) {
+                        throw std::runtime_error("Roi and od meta are not the same region");
+                    }
+
+                    get_od_id(od_mtd, &meta_id);
+                }
+
+                for (const GstStructure *roi_classification : inference_roi->roi_classifications) {
+                    UpdateClassificationHistory(meta_id, (*frame).filter, roi_classification);
+                }
+            }
+
+            // 'output_frames' queue can be shared across streams and it is subject to HOL blocking
+            // do not send frame to a blocked output, but check if there frames ready to non-blocked outputs
+            if (CheckSrcPadBlocked(src)) {
+                output_full[src->name] = true;
+                frame++; // output blocked, try next frame
+            } else {
+                frames_to_push.push_back(std::move(*frame));
+                frame = output_frames.erase(frame);
             }
         }
+    } // output_frames_mutex released
 
-        // 'output_frames' queue can be shared across streams and it is subject to HOL blocking
-        // do not send frame to a blocked output, but check if there frames ready to non-blocked outputs
-        GstObject *src = &(*frame).filter->base_transform.element.object;
-        if (CheckSrcPadBlocked(src) || output_full[src->name]) {
-            output_full[src->name] = true;
-            frame++; // output blocked, try next frame
-        } else {
-            PushBufferToSrcPad(*frame);
-            frame = output_frames.erase(frame);
-        }
+    // Push collected frames downstream without holding output_frames_mutex
+    for (auto &f : frames_to_push) {
+        PushBufferToSrcPad(f);
     }
 }
 
@@ -1250,6 +1291,7 @@ InferenceImpl::MakeInferenceResult(GvaBaseInference *gva_base_inference, Model &
 
     result->model = &model;
     result->image = image;
+    result->source_tag = gva_base_inference;
     return result;
 }
 
@@ -1313,7 +1355,6 @@ const InferenceImpl::Model &InferenceImpl::GetModel() const {
 
 GstFlowReturn InferenceImpl::TransformFrameIp(GvaBaseInference *gva_base_inference, GstBuffer *buffer) {
     ITT_TASK(__FUNCTION__);
-    std::unique_lock<std::mutex> lock(_mutex);
 
     assert(gva_base_inference != nullptr && "Expected a valid pointer to gva_base_inference");
     assert(gva_base_inference->info != nullptr && "Expected a valid pointer to GstVideoInfo");
@@ -1393,10 +1434,8 @@ GstFlowReturn InferenceImpl::TransformFrameIp(GvaBaseInference *gva_base_inferen
         GstObject *src = &gva_base_inference->base_transform.element.object;
         while (CheckSrcPadBlocked(src)) {
             output_lock.unlock();
-            lock.unlock();
             GVA_INFO("Wait on blocking output <%s>", src->name);
             std::this_thread::sleep_for(std::chrono::milliseconds(10));
-            lock.lock();
             output_lock.lock();
         }
 
@@ -1414,9 +1453,7 @@ GstFlowReturn InferenceImpl::TransformFrameIp(GvaBaseInference *gva_base_inferen
                    (output_frames.size() > model.inference->GetNireq() * model.inference->GetBatchSize() *
                                                gva_base_inference->inference_interval)) {
                 output_lock.unlock();
-                lock.unlock();
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                lock.lock();
                 output_lock.lock();
                 for (const auto &output_frame : output_frames)
                     if ((output_frame.buffer->pts != GST_CLOCK_TIME_NONE) && (output_frame.buffer->pts > latest_pts))

--- a/src/monolithic/gst/inference_elements/base/inference_impl.h
+++ b/src/monolithic/gst/inference_elements/base/inference_impl.h
@@ -18,6 +18,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <shared_mutex>
 #include <string>
 #include <vector>
 
@@ -78,7 +79,8 @@ class InferenceImpl {
 
     std::vector<std::string> object_classes;
 
-    mutable std::mutex _mutex;
+    // Protects object_classes. Use shared_lock for reads, unique_lock for writes.
+    mutable std::shared_mutex _mutex;
     Model model;
     std::shared_ptr<InferenceBackend::Allocator> allocator;
 

--- a/src/monolithic/gst/inference_elements/base/inference_singleton.cpp
+++ b/src/monolithic/gst/inference_elements/base/inference_singleton.cpp
@@ -194,6 +194,12 @@ void release_inference_instance(GvaBaseInference *base_inference) {
         for (auto it = inference_pool_.begin(); it != inference_pool_.end();) {
             auto infRefs = it->second;
             infRefs->refs.erase(base_inference);
+
+            // Unregister this element from fair-batch source tracking
+            if (infRefs->proxy && infRefs->proxy->GetModel().inference) {
+                infRefs->proxy->GetModel().inference->UnregisterSource(base_inference);
+            }
+
             if (infRefs->refs.empty()) {
                 infRefs->proxy.reset();
                 infRefs.reset();

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -40,6 +40,7 @@
 #endif
 #endif
 
+#include <chrono>
 #include <functional>
 #include <iterator>
 #include <regex>
@@ -1269,6 +1270,7 @@ OpenVINOImageInference::~OpenVINOImageInference() {
 void OpenVINOImageInference::FreeRequest(std::shared_ptr<BatchRequest> request) {
     const size_t buffer_size = request->buffers.size();
     request->buffers.clear();
+    request->source_counts.clear();
     for (auto &in_vec : request->in_tensors) {
         in_vec.clear();
     }
@@ -1449,39 +1451,83 @@ void OpenVINOImageInference::SubmitImage(
     if (!frame)
         throw std::invalid_argument("Invalid frame provided");
 
-    std::unique_lock<std::mutex> lk(requests_mutex_);
-    ++requests_processing_;
-    std::shared_ptr<BatchRequest> request = freeRequests.pop();
-
-    try {
-        if (DoNeedImagePreProcessing(frame->GetImage())) {
-            SubmitImageProcessing(
-                image_layer, request, *frame->GetImage(),
-                getImagePreProcInfo(input_preprocessors), // contain operations order for Custom Image PreProcessing
-                frame->GetImageTransformationParams()     // during CIPP will be filling of crop and aspect-ratio
-                                                          // parameters
-            );
-        } else {
-            BypassImageProcessing(image_layer, request, *frame->GetImage(), safe_convert<size_t>(batch_size));
-        }
-
-        ApplyInputPreprocessors(request, input_preprocessors);
-
-        request->buffers.push_back(frame);
-    } catch (const std::exception &e) {
-        GVA_ERROR("Pre-processing has failed: %s", e.what());
-        std::throw_with_nested(std::runtime_error("Pre-processing was failed."));
+    // Register source for fair batch scheduling (used as opaque key only — never dereference)
+    void *source = frame->source_tag;
+    if (source) {
+        std::lock_guard<std::mutex> sg(sources_mutex_);
+        known_sources_.insert(source);
     }
 
-    try {
-        // start inference asynchronously if enough buffers for batching
-        if (request->buffers.size() >= safe_convert<size_t>(batch_size)) {
-            request->start_async();
-        } else {
-            freeRequests.push_front(request);
+    const int max_retries = batch_size * 4;
+    for (int retry = 0;; ++retry) {
+        std::unique_lock<std::mutex> lk(requests_mutex_);
+        ++requests_processing_;
+        std::shared_ptr<BatchRequest> request = freeRequests.pop();
+
+        // Fair batch cap: if this source already has its fair share, wait for others to contribute
+        if (source && batch_size > 1 && retry < max_retries) {
+            size_t num_sources;
+            {
+                std::lock_guard<std::mutex> sg(sources_mutex_);
+                num_sources = known_sources_.size();
+            }
+            if (num_sources > 1) {
+                size_t max_per_source =
+                    std::max(size_t(1), (static_cast<size_t>(batch_size) + num_sources - 1) / num_sources);
+                auto it = request->source_counts.find(source);
+                size_t current = (it != request->source_counts.end()) ? it->second : 0;
+                if (current >= max_per_source) {
+                    freeRequests.push_front(request);
+                    --requests_processing_;
+                    // Wait until another source adds a frame (or timeout)
+                    batch_fair_cv_.wait_for(lk, std::chrono::milliseconds(2));
+                    lk.unlock();
+                    continue;
+                }
+            }
         }
-    } catch (const std::exception &e) {
-        std::throw_with_nested(std::runtime_error("Inference async start was failed."));
+
+        try {
+            if (DoNeedImagePreProcessing(frame->GetImage())) {
+                SubmitImageProcessing(
+                    image_layer, request, *frame->GetImage(),
+                    getImagePreProcInfo(input_preprocessors), // contain operations order for Custom Image PreProcessing
+                    frame->GetImageTransformationParams()     // during CIPP will be filling of crop and aspect-ratio
+                                                              // parameters
+                );
+            } else {
+                BypassImageProcessing(image_layer, request, *frame->GetImage(), safe_convert<size_t>(batch_size));
+            }
+
+            ApplyInputPreprocessors(request, input_preprocessors);
+
+            if (source) {
+                request->source_counts[source]++;
+            }
+            request->buffers.push_back(frame);
+            batch_fair_cv_.notify_all();
+        } catch (...) {
+            // Restore invariants: return the request and decrement the counter
+            handleError(request->buffers);
+            FreeRequest(request);
+            std::throw_with_nested(std::runtime_error("Pre-processing failed in SubmitImage"));
+        }
+
+        try {
+            // start inference asynchronously if enough buffers for batching
+            if (request->buffers.size() >= safe_convert<size_t>(batch_size)) {
+                request->start_async();
+            } else {
+                freeRequests.push_front(request);
+            }
+        } catch (...) {
+            // Inference start failed — return request to pool so it's not leaked
+            handleError(request->buffers);
+            FreeRequest(request);
+            std::throw_with_nested(std::runtime_error("Inference async start failed in SubmitImage"));
+        }
+
+        break; // success — exit retry loop
     }
 }
 
@@ -1584,6 +1630,13 @@ void OpenVINOImageInference::Close() {
         auto req = freeRequests.pop();
         req->infer_request_new.set_callback([](std::exception_ptr) {});
     }
+}
+
+void OpenVINOImageInference::UnregisterSource(void *source) {
+    if (!source)
+        return;
+    std::lock_guard<std::mutex> sg(sources_mutex_);
+    known_sources_.erase(source);
 }
 
 void OpenVINOImageInference::WorkingFunction(const std::shared_ptr<BatchRequest> &request) {

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <gst/gst.h>
 #include <map>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -53,6 +54,8 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
 
     void Close() override;
 
+    void UnregisterSource(void *source) override;
+
   protected:
     std::unique_ptr<class OpenVinoNewApiImpl> _impl;
 
@@ -60,6 +63,7 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
         ov::InferRequest infer_request_new;
         std::vector<IFrameBase::Ptr> buffers;
         std::vector<ov::TensorVector> in_tensors;
+        std::map<void *, size_t> source_counts;
 
         void start_async() {
             return this->infer_request_new.start_async();
@@ -89,6 +93,11 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
     std::atomic<unsigned int> requests_processing_;
     std::condition_variable request_processed_;
     std::mutex flush_mutex;
+
+    // Fair batch scheduling: track known sources for per-source cap
+    std::set<void *> known_sources_;
+    std::mutex sources_mutex_;
+    std::condition_variable batch_fair_cv_;
 
   private:
     void FreeRequest(std::shared_ptr<BatchRequest> request);

--- a/src/monolithic/inference_backend/include/inference_backend/image_inference.h
+++ b/src/monolithic/inference_backend/include/inference_backend/image_inference.h
@@ -44,6 +44,11 @@ class ImageInference {
             return image_trans_params;
         }
 
+        // Opaque tag identifying the source (e.g. GStreamer element) that produced this frame.
+        // Used by the inference backend for fair batch scheduling across multiple sources.
+        // NOTE: Used as an opaque key for identity comparison only — NEVER dereference.
+        void *source_tag = nullptr;
+
         virtual ~IFrameBase() = default;
     };
 
@@ -76,6 +81,14 @@ class ImageInference {
     virtual bool IsQueueFull() = 0;
     virtual void Flush() = 0;
     virtual void Close() = 0;
+
+    /**
+     * Remove a source from fair-batch tracking
+     * call when stream/element is torn down)
+     */
+    virtual void UnregisterSource(void *source) {
+        (void)source;
+    }
 
     virtual ~ImageInference() = default;
 };


### PR DESCRIPTION
### Description

When multiple GStreamer pipelines share an InferenceImpl instance via model-instance-id, two lock-related issues cause stream starvation:

1. PushOutput() held output_frames_mutex while calling gst_pad_push() downstream via PushBufferToSrcPad(). Since gst_pad_push() can block (e.g. sync=true with clock wait, or downstream queue full), this held the mutex for 20-30ms per frame. Other streaming threads calling TransformFrameIp were blocked from pushing into output_frames, causing cascading starvation.

   Fix: Collect completed frames into a local vector under the lock, then release the lock before pushing them downstream. Also fixes head-of-line blocking by skipping incomplete frames on a per-stream basis rather than stopping iteration entirely.

2. TransformFrameIp held _mutex for its entire duration (~13ms), serializing all streams through a single critical section. This mutex is unnecessary because every operation within the function is either per-element (not shared), per-buffer, or already protected by a finer-grained lock (output_frames_mutex, requests_mutex_, freeRequests condvar).

   Fix: Remove _mutex from TransformFrameIp. The remaining use in UpdateObjectClasses is retained as it protects shared object_classes during multichannel reconfiguration.

### How Has This Been Tested?

Tested with 21 concurrent streams sharing 7 model instances on Intel
Core Ultra 7 265K (2 P-cores, iGPU, batch-size=1): all streams
sustain 30fpshanges. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

**batch_timeout (tested with 100ms) is needed as long as we use only 2 P-core to mitigate another shortcoming of low number of MC don't fill GPU queue fast enough.**

general test can be performed using higher numbers of concurrent streams to get the highest can be processed using a certain number of model instances

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

