### PR TITLE
Add MonoDETR monocular 3D object detection support

### DIFF
--- a/src/gst/metadata/CMakeLists.txt
+++ b/src/gst/metadata/CMakeLists.txt
@@ -20,6 +20,7 @@ target_include_directories(${TARGET_NAME}
         PUBLIC
                 ${GSTREAMER_INCLUDE_DIRS}
                 ${GSTVIDEO_INCLUDE_DIRS}
+                ${GSTANALYTICS_INCLUDE_DIRS}
                 ${GLIB2_INCLUDE_DIRS}
         PRIVATE
                 ${GSTALLOC_INCLUDE_DIRS}

--- a/src/monolithic/gst/inference_elements/base/gva_base_inference.cpp
+++ b/src/monolithic/gst/inference_elements/base/gva_base_inference.cpp
@@ -85,6 +85,8 @@
 
 #define DEFAULT_OV_EXTENSION_LIB nullptr
 
+#define DEFAULT_INTRINSICS_FILE nullptr
+
 #define DEFAULT_SHARE_VADISPLAY_CTX TRUE
 
 G_DEFINE_TYPE_WITH_PRIVATE(GvaBaseInference, gva_base_inference, GST_TYPE_BASE_TRANSFORM);
@@ -122,6 +124,7 @@ enum {
     PROP_CUSTOM_PREPROC_LIB,
     PROP_CUSTOM_POSTPROC_LIB,
     PROP_OV_EXTENSION_LIB,
+    PROP_INTRINSICS_FILE,
     PROP_SHARE_VADISPLAY_CTX,
     PROP_CORE_PINNING
 };
@@ -253,6 +256,15 @@ void gva_base_inference_class_init(GvaBaseInferenceClass *klass) {
                                     g_param_spec_string("ov-extension-lib", "OpenVINO Extension Library",
                                                         "Path to the .so file defining custom OpenVINO operations.",
                                                         DEFAULT_OV_EXTENSION_LIB, param_flags));
+
+    g_object_class_install_property(
+        gobject_class, PROP_INTRINSICS_FILE,
+        g_param_spec_string("intrinsics-file", "Camera Intrinsics File",
+                            "Path to a JSON file with camera calibration used by the MonoDETR (mono3d) "
+                            "post-processor to lift 2D detections into 3D. Supports an \"intrinsic_matrix\" "
+                            "(3x3) or \"projection_matrix\" (3x4) and an optional \"image_size\" [W, H]. "
+                            "Same schema as the gvawatermark3d element.",
+                            DEFAULT_INTRINSICS_FILE, param_flags));
 
     g_object_class_install_property(
         gobject_class, PROP_MODEL_INSTANCE_ID,
@@ -502,6 +514,9 @@ void gva_base_inference_cleanup(GvaBaseInference *base_inference) {
 
     g_free(base_inference->ov_extension_lib);
     base_inference->ov_extension_lib = nullptr;
+
+    g_free(base_inference->intrinsics_file);
+    base_inference->intrinsics_file = nullptr;
 }
 
 /**
@@ -630,6 +645,7 @@ void gva_base_inference_init(GvaBaseInference *base_inference) {
     base_inference->custom_preproc_lib = g_strdup(DEFAULT_MODEL_PROC);
     base_inference->custom_postproc_lib = g_strdup(DEFAULT_CUSTOM_POSTPROC_LIB);
     base_inference->ov_extension_lib = g_strdup(DEFAULT_OV_EXTENSION_LIB);
+    base_inference->intrinsics_file = g_strdup(DEFAULT_INTRINSICS_FILE);
 
     base_inference->share_va_display_ctx = DEFAULT_SHARE_VADISPLAY_CTX;
 #ifndef _WIN32
@@ -983,6 +999,11 @@ void gva_base_inference_set_property(GObject *object, guint property_id, const G
         base_inference->ov_extension_lib = g_value_dup_string(value);
         GST_INFO_OBJECT(base_inference, "ov-extension-lib: %s", base_inference->ov_extension_lib);
         break;
+    case PROP_INTRINSICS_FILE:
+        g_free(base_inference->intrinsics_file);
+        base_inference->intrinsics_file = g_value_dup_string(value);
+        GST_INFO_OBJECT(base_inference, "intrinsics-file: %s", base_inference->intrinsics_file);
+        break;
     case PROP_SHARE_VADISPLAY_CTX:
         base_inference->share_va_display_ctx = g_value_get_boolean(value);
         break;
@@ -1075,6 +1096,9 @@ void gva_base_inference_get_property(GObject *object, guint property_id, GValue 
         break;
     case PROP_OV_EXTENSION_LIB:
         g_value_set_string(value, base_inference->ov_extension_lib);
+        break;
+    case PROP_INTRINSICS_FILE:
+        g_value_set_string(value, base_inference->intrinsics_file);
         break;
     case PROP_SHARE_VADISPLAY_CTX:
         g_value_set_boolean(value, base_inference->share_va_display_ctx);

--- a/src/monolithic/gst/inference_elements/base/gva_base_inference.h
+++ b/src/monolithic/gst/inference_elements/base/gva_base_inference.h
@@ -79,6 +79,7 @@ typedef struct _GvaBaseInference {
     gchar *custom_preproc_lib;
     gchar *custom_postproc_lib;
     gchar *ov_extension_lib;
+    gchar *intrinsics_file;
 
     // other fields
     struct GvaBaseInferencePrivate *priv;

--- a/src/monolithic/gst/inference_elements/base/inference_impl.cpp
+++ b/src/monolithic/gst/inference_elements/base/inference_impl.cpp
@@ -8,6 +8,7 @@
 
 #include "common/post_processor.h"
 #include "common/post_processor/post_proc_common.h"
+#include "common/mono3d_calibration.h"
 #include "common/pre_processor_info_parser.hpp"
 #include "common/pre_processors.h"
 #include "config.h"
@@ -823,6 +824,61 @@ dlstreamer::ContextPtr createVaDisplay(GvaBaseInference *gva_base_inference) {
     return display;
 }
 
+// Detects the MonoDETR-style auxiliary inputs (a 3x4 camera-projection "calib" input and a
+// [B,2] "img_sizes" input) directly from the model file and, when present, appends
+// ModelInputProcessorInfo entries so the backend feeds them. The values come from the
+// gvadetect "intrinsics-file" property (falling back to the source frame size).
+void AppendMono3DAuxInputs(GvaBaseInference *gva_base_inference, const std::string &model_file,
+                           std::vector<ModelInputProcessorInfo::Ptr> &input_processor_info) {
+    std::map<std::string, std::vector<size_t>> input_shapes;
+    try {
+        input_shapes = ImageInference::GetModelInputShapes(model_file, gva_base_inference->ov_extension_lib);
+    } catch (const std::exception &e) {
+        GST_WARNING_OBJECT(gva_base_inference, "mono3d: failed to read model input shapes: %s", e.what());
+        return;
+    }
+
+    std::string calib_layer, img_sizes_layer;
+    for (const auto &kv : input_shapes) {
+        const auto &dims = kv.second;
+        if (dims.size() == 3 && dims[1] == 3 && dims[2] == 4)
+            calib_layer = kv.first;
+        else if (dims.size() == 2 && dims[1] == 2)
+            img_sizes_layer = kv.first;
+    }
+
+    // Only a model that exposes BOTH auxiliary inputs is treated as MonoDETR-style.
+    if (calib_layer.empty() || img_sizes_layer.empty())
+        return;
+
+    // Don't override inputs already configured (e.g. via a model-proc file).
+    for (const auto &p : input_processor_info) {
+        if (p->layer_name == calib_layer || p->layer_name == img_sizes_layer)
+            return;
+    }
+
+    const int default_w = gva_base_inference->info ? gva_base_inference->info->width : 0;
+    const int default_h = gva_base_inference->info ? gva_base_inference->info->height : 0;
+    const post_processing::Mono3DCalibration calib = post_processing::parseMono3DIntrinsics(
+        gva_base_inference->intrinsics_file ? gva_base_inference->intrinsics_file : "", default_w, default_h);
+
+    const auto make_info = [&calib](const std::string &layer, const std::string &fmt) {
+        auto info = std::make_shared<ModelInputProcessorInfo>();
+        info->format = fmt;
+        info->layer_name = layer;
+        info->precision = "FP32";
+        info->params = gst_structure_new_empty(fmt.c_str());
+        post_processing::applyMono3DCalibrationToStructure(info->params, calib);
+        return info;
+    };
+
+    input_processor_info.push_back(make_info(calib_layer, "calib"));
+    input_processor_info.push_back(make_info(img_sizes_layer, "img_sizes"));
+
+    GST_INFO_OBJECT(gva_base_inference, "mono3d: configured auxiliary inputs calib='%s' img_sizes='%s' (image %dx%d)",
+                    calib_layer.c_str(), img_sizes_layer.c_str(), calib.orig_width, calib.orig_height);
+}
+
 } // namespace
 
 InferenceImpl::Model InferenceImpl::CreateModel(GvaBaseInference *gva_base_inference, const std::string &model_file,
@@ -875,6 +931,9 @@ InferenceImpl::Model InferenceImpl::CreateModel(GvaBaseInference *gva_base_infer
 
     // It will be parsed in PostProcessor
     model.labels = labels_str;
+
+    // For MonoDETR-style models, append feeders for the camera-calibration and image-size inputs.
+    AppendMono3DAuxInputs(gva_base_inference, model_file, model.input_processor_info);
 
     UpdateModelReshapeInfo(gva_base_inference);
     InferenceConfig ie_config = CreateNestedInferenceConfig(gva_base_inference, model_file, custom_preproc_lib);

--- a/src/monolithic/gst/inference_elements/common/mono3d_calibration.cpp
+++ b/src/monolithic/gst/inference_elements/common/mono3d_calibration.cpp
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "mono3d_calibration.h"
+
+#include <nlohmann/json.hpp>
+
+#include <fstream>
+
+namespace post_processing {
+
+Mono3DCalibration parseMono3DIntrinsics(const std::string &intrinsics_file, int default_width, int default_height) {
+    Mono3DCalibration calib;
+    calib.orig_width = default_width;
+    calib.orig_height = default_height;
+    // Identity-like default projection (overwritten when a valid file is provided).
+    calib.p2 = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0};
+
+    if (intrinsics_file.empty())
+        return calib;
+
+    try {
+        std::ifstream f(intrinsics_file);
+        if (!f.is_open())
+            return calib;
+
+        nlohmann::json j;
+        f >> j;
+
+        if (j.contains("projection_matrix") && j["projection_matrix"].is_array()) {
+            const auto &m = j["projection_matrix"];
+            if (m.size() == 3) {
+                for (int r = 0; r < 3; ++r)
+                    for (int c = 0; c < 4; ++c)
+                        calib.p2[r * 4 + c] = m[r][c].get<double>();
+                calib.valid = true;
+            }
+        } else if (j.contains("intrinsic_matrix") && j["intrinsic_matrix"].is_array()) {
+            const auto &k = j["intrinsic_matrix"];
+            if (k.size() == 3) {
+                // P2 = [K | 0]
+                for (int r = 0; r < 3; ++r) {
+                    for (int c = 0; c < 3; ++c)
+                        calib.p2[r * 4 + c] = k[r][c].get<double>();
+                    calib.p2[r * 4 + 3] = 0.0;
+                }
+                calib.valid = true;
+            }
+        }
+
+        if (j.contains("image_size") && j["image_size"].is_array() && j["image_size"].size() == 2) {
+            calib.orig_width = j["image_size"][0].get<int>();
+            calib.orig_height = j["image_size"][1].get<int>();
+        }
+    } catch (const std::exception &) {
+        // Leave calib.valid as-is; caller falls back to defaults.
+    }
+
+    return calib;
+}
+
+void applyMono3DCalibrationToStructure(GstStructure *s, const Mono3DCalibration &calib) {
+    if (!s)
+        return;
+
+    GValue arr = G_VALUE_INIT;
+    g_value_init(&arr, GST_TYPE_ARRAY);
+    for (double v : calib.p2) {
+        GValue item = G_VALUE_INIT;
+        g_value_init(&item, G_TYPE_DOUBLE);
+        g_value_set_double(&item, v);
+        gst_value_array_append_value(&arr, &item);
+        g_value_unset(&item);
+    }
+    gst_structure_set_value(s, "P2", &arr);
+    g_value_unset(&arr);
+
+    gst_structure_set(s, "orig_width", G_TYPE_INT, calib.orig_width, "orig_height", G_TYPE_INT, calib.orig_height,
+                      NULL);
+}
+
+} // namespace post_processing

--- a/src/monolithic/gst/inference_elements/common/mono3d_calibration.h
+++ b/src/monolithic/gst/inference_elements/common/mono3d_calibration.h
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#pragma once
+
+#include <gst/gst.h>
+
+#include <array>
+#include <string>
+
+namespace post_processing {
+
+// Camera calibration used by the MonoDETR ("mono3d") pipeline. P2 is a KITTI-style
+// 3x4 projection matrix stored row-major. orig_width/orig_height are the pixel
+// dimensions of the image the calibration refers to (and that the model's img_sizes
+// input expects).
+struct Mono3DCalibration {
+    bool valid = false;
+    std::array<double, 12> p2{};
+    int orig_width = 0;
+    int orig_height = 0;
+};
+
+// Parses a JSON intrinsics file (same schema as gvawatermark3d) and derives P2:
+//   - "projection_matrix": 3x4 array  -> used directly as P2 (takes precedence)
+//   - "intrinsic_matrix":  3x3 array  -> P2 = [K | 0]
+//   - "image_size": [W, H]            -> original image size (optional)
+// default_width/default_height are used for the image size when "image_size" is absent.
+// On any failure the returned calibration has valid == false (but image size defaults are filled).
+Mono3DCalibration parseMono3DIntrinsics(const std::string &intrinsics_file, int default_width, int default_height);
+
+// Writes P2 (as a GST_TYPE_ARRAY of 12 doubles named "P2") and orig_width/orig_height
+// (as ints) onto the given structure. Used to feed both the model inputs (calib/img_sizes)
+// and the mono3d post-processor.
+void applyMono3DCalibrationToStructure(GstStructure *s, const Mono3DCalibration &calib);
+
+} // namespace post_processing

--- a/src/monolithic/gst/inference_elements/common/post_processor.cpp
+++ b/src/monolithic/gst/inference_elements/common/post_processor.cpp
@@ -11,6 +11,7 @@
 #include "gva_base_inference.h"
 #include "inference_backend/logger.h"
 #include "inference_impl.h"
+#include "mono3d_calibration.h"
 #include "model_proc_provider.h"
 
 #include <map>
@@ -180,6 +181,22 @@ PostProcessor::PostProcessor(InferenceImpl *inference_impl, GvaBaseInference *ba
     /* if model proc is empty check if post-processing info can be derived from model metadata */
     if (initializer.output_processors.empty()) {
         initializer.output_processors = model.inference->GetModelInfoPostproc();
+    }
+    /* feed camera calibration to the MonoDETR ("mono3d") post-processor: it needs P2 and the
+     * original image size to lift 2D detections into 3D. These come from the gvadetect
+     * "intrinsics-file" property (falling back to the source frame size). */
+    for (const auto &output_processor : initializer.output_processors) {
+        GstStructure *s = output_processor.second;
+        if (!s)
+            continue;
+        const gchar *converter = gst_structure_get_string(s, "converter");
+        if (converter && g_strcmp0(converter, "mono3d") == 0) {
+            const int default_w = base_inference->info ? base_inference->info->width : 0;
+            const int default_h = base_inference->info ? base_inference->info->height : 0;
+            const Mono3DCalibration calib = parseMono3DIntrinsics(
+                base_inference->intrinsics_file ? base_inference->intrinsics_file : "", default_w, default_h);
+            applyMono3DCalibrationToStructure(s, calib);
+        }
     }
     /* set output labels */
     // NOTE: must be called after setting output_processors

--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.cpp
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.cpp
@@ -12,6 +12,7 @@
 #include "custom_to_roi.h"
 #include "detection_output.h"
 #include "mask_rcnn.h"
+#include "mono3d.h"
 #include "rtdetr.h"
 #include "yolo_base.h"
 #include "yolo_v10.h"
@@ -97,6 +98,8 @@ BlobToMetaConverter::Ptr BlobToROIConverter::create(BlobToMetaConverter::Initial
             new YOLOv26SegConverter(std::move(initializer), confidence_threshold, iou_threshold));
     else if (converter_name == RTDETRConverter::getName())
         return BlobToMetaConverter::Ptr(new RTDETRConverter(std::move(initializer), confidence_threshold));
+    else if (converter_name == Mono3DConverter::getName())
+        return BlobToMetaConverter::Ptr(new Mono3DConverter(std::move(initializer), confidence_threshold));
     else if (converter_name == MaskRCNNConverter::getName())
         return BlobToMetaConverter::Ptr(
             new MaskRCNNConverter(std::move(initializer), confidence_threshold, iou_threshold));

--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.h
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/blob_to_roi_converter.h
@@ -36,6 +36,10 @@ class BlobToROIConverter : public BlobToMetaConverter {
 
         std::vector<GstStructure *> tensors;
 
+        // Optional JSON string with extra (e.g. 3D) parameters attached to the "detection" structure.
+        // Consumed by downstream elements such as gvawatermark3d / gvadeskew.
+        std::string extra_params_json;
+
         DetectedObject(double x, double y, double w, double h, double r, double confidence, size_t label_id,
                        const std::string &label, double w_scale = 1.f, double h_scale = 1.f,
                        bool relative_to_center = false)
@@ -72,6 +76,9 @@ class BlobToROIConverter : public BlobToMetaConverter {
 
             if (not label.empty())
                 gst_structure_set(detection_tensor, "label", G_TYPE_STRING, label.c_str(), NULL);
+
+            if (not extra_params_json.empty())
+                gst_structure_set(detection_tensor, "extra_params_json", G_TYPE_STRING, extra_params_json.c_str(), NULL);
 
             std::vector<GstStructure *> results{detection_tensor};
             for (size_t i = 0; i < tensors.size(); i++)

--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/mono3d.cpp
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/mono3d.cpp
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#include "mono3d.h"
+
+#include "inference_backend/image_inference.h"
+#include "inference_backend/logger.h"
+
+#include <gst/gst.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdio>
+#include <map>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+using namespace post_processing;
+
+namespace {
+
+constexpr size_t NUM_HEADING_BIN = 12;
+
+inline float sigmoid(float x) {
+    return 1.0f / (1.0f + std::exp(-x));
+}
+
+std::string toLower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(), [](unsigned char c) { return std::tolower(c); });
+    return s;
+}
+
+const float *blobData(const InferenceBackend::OutputBlob::Ptr &blob) {
+    if (!blob)
+        throw std::invalid_argument("mono3d: output blob is nullptr.");
+    if (blob->GetPrecision() != InferenceBackend::Blob::Precision::FP32)
+        throw std::runtime_error("mono3d: unsupported output precision (expected FP32).");
+    return reinterpret_cast<const float *>(blob->GetData());
+}
+
+// Inverse of angle2class: angle = cls * (2pi/bins) + residual, wrapped to (-pi, pi].
+float class2angle(size_t cls, float residual) {
+    const float angle_per_class = 2.0f * static_cast<float>(M_PI) / static_cast<float>(NUM_HEADING_BIN);
+    float angle = static_cast<float>(cls) * angle_per_class + residual;
+    if (angle > static_cast<float>(M_PI))
+        angle -= 2.0f * static_cast<float>(M_PI);
+    return angle;
+}
+
+// heading: 24 values = 12 bin logits + 12 residuals
+float getHeadingAngle(const float *heading) {
+    size_t best_bin = 0;
+    float best_val = heading[0];
+    for (size_t i = 1; i < NUM_HEADING_BIN; ++i) {
+        if (heading[i] > best_val) {
+            best_val = heading[i];
+            best_bin = i;
+        }
+    }
+    const float residual = heading[NUM_HEADING_BIN + best_bin];
+    return class2angle(best_bin, residual);
+}
+
+std::string buildExtraParamsJson(double X, double Y, double Z, double l, double w, double h, double ry) {
+    // rotation: quaternion about Y axis, scipy order [x, y, z, w]
+    const double qy = std::sin(ry / 2.0);
+    const double qw = std::cos(ry / 2.0);
+
+    std::ostringstream os;
+    os.setf(std::ios::fixed);
+    os.precision(6);
+    os << "{\"translation\":[" << X << "," << Y << "," << Z << "],"
+       << "\"dimension\":[" << l << "," << w << "," << h << "],"
+       << "\"rotation\":[0," << qy << ",0," << qw << "]}";
+    return os.str();
+}
+
+} // namespace
+
+Mono3DConverter::Calibration Mono3DConverter::readCalibration() const {
+    Calibration calib{};
+    // Defaults: identity-ish intrinsics scaled to the model input, no translation.
+    const auto &image_info = getModelInputImageInfo();
+    const double def_w = static_cast<double>(image_info.width);
+    const double def_h = static_cast<double>(image_info.height);
+    calib.orig_width = def_w > 0 ? def_w : 1.0;
+    calib.orig_height = def_h > 0 ? def_h : 1.0;
+    calib.p2 = {def_w, 0, def_w / 2.0, 0, 0, def_h, def_h / 2.0, 0, 0, 0, 1, 0};
+
+    const GstStructure *params = getModelProcOutputInfo().get();
+    if (!params)
+        return calib;
+
+    GValueArray *arr = nullptr;
+    if (gst_structure_get_array(const_cast<GstStructure *>(params), "P2", &arr) && arr) {
+        if (arr->n_values == 12) {
+            for (guint i = 0; i < 12; ++i)
+                calib.p2[i] = g_value_get_double(g_value_array_get_nth(arr, i));
+        }
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+        g_value_array_free(arr);
+        G_GNUC_END_IGNORE_DEPRECATIONS
+    }
+
+    int iw = 0, ih = 0;
+    if (gst_structure_get_int(params, "orig_width", &iw) && iw > 0)
+        calib.orig_width = static_cast<double>(iw);
+    if (gst_structure_get_int(params, "orig_height", &ih) && ih > 0)
+        calib.orig_height = static_cast<double>(ih);
+
+    return calib;
+}
+
+size_t Mono3DConverter::readTopK() const {
+    int topk = 50;
+    const GstStructure *params = getModelProcOutputInfo().get();
+    if (params)
+        gst_structure_get_int(params, "topk", &topk);
+    if (topk <= 0)
+        topk = 50;
+    return static_cast<size_t>(topk);
+}
+
+std::vector<float> Mono3DConverter::readClassMeanSizes(size_t num_classes) const {
+    std::vector<float> mean_sizes(num_classes * 3, 0.0f);
+    const GstStructure *params = getModelProcOutputInfo().get();
+    if (!params)
+        return mean_sizes;
+
+    GValueArray *arr = nullptr;
+    if (gst_structure_get_array(const_cast<GstStructure *>(params), "cls_mean_size", &arr) && arr) {
+        if (arr->n_values == mean_sizes.size()) {
+            for (guint i = 0; i < arr->n_values; ++i)
+                mean_sizes[i] = static_cast<float>(g_value_get_double(g_value_array_get_nth(arr, i)));
+        }
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+        g_value_array_free(arr);
+        G_GNUC_END_IGNORE_DEPRECATIONS
+    }
+    return mean_sizes;
+}
+
+void Mono3DConverter::parseOutputs(const float *logits, const std::vector<size_t> &logits_dims, const float *boxes,
+                                   const float *dim3d, const float *depth, const float *angle, const Calibration &calib,
+                                   const std::vector<float> &cls_mean_size,
+                                   std::vector<DetectedObject> &objects) const {
+    const size_t num_queries = logits_dims[logits_dims.size() - 2];
+    const size_t num_classes = logits_dims.back();
+    if (num_queries == 0 || num_classes == 0)
+        throw std::invalid_argument("mono3d: logits output has zero queries or classes.");
+
+    const size_t topk = std::min(readTopK(), num_queries * num_classes);
+
+    // Top-k over the flattened (query x class) sigmoid scores.
+    std::vector<std::tuple<float, size_t, size_t>> scored; // (score, query, class)
+    scored.reserve(num_queries * num_classes);
+    for (size_t q = 0; q < num_queries; ++q)
+        for (size_t c = 0; c < num_classes; ++c)
+            scored.emplace_back(sigmoid(logits[q * num_classes + c]), q, c);
+
+    std::partial_sort(scored.begin(), scored.begin() + topk, scored.end(),
+                      [](const auto &a, const auto &b) { return std::get<0>(a) > std::get<0>(b); });
+
+    // Calibration scalars
+    const double fu = calib.p2[0];
+    const double cu = calib.p2[2];
+    const double fv = calib.p2[5];
+    const double cv = calib.p2[6];
+    const double tx = (fu != 0.0) ? calib.p2[3] / (-fu) : 0.0;
+    const double ty = (fv != 0.0) ? calib.p2[7] / (-fv) : 0.0;
+    const double orig_w = calib.orig_width;
+    const double orig_h = calib.orig_height;
+
+    for (size_t i = 0; i < topk; ++i) {
+        const float score_raw = std::get<0>(scored[i]);
+        const size_t q = std::get<1>(scored[i]);
+        const size_t cls = std::get<2>(scored[i]);
+
+        // 2D box (normalized cxcylrtb)
+        const float *box = boxes + q * 6;
+        const double bcx = box[0];
+        const double bcy = box[1];
+        const double bl = box[2];
+        const double br = box[3];
+        const double bt = box[4];
+        const double bb = box[5];
+
+        const double x1n = bcx - bl;
+        const double y1n = bcy - bt;
+        const double x2n = bcx + br;
+        const double y2n = bcy + bb;
+
+        // depth + uncertainty
+        const double depth_val = depth[q * 2 + 0];
+        const double sigma_raw = depth[q * 2 + 1];
+        const double score = static_cast<double>(score_raw) * std::exp(-sigma_raw);
+
+        if (score < confidence_threshold)
+            continue;
+
+        // 3D dimensions (h, w, l) + per-class mean size
+        double h3d = dim3d[q * 3 + 0] + cls_mean_size[cls * 3 + 0];
+        double w3d = dim3d[q * 3 + 1] + cls_mean_size[cls * 3 + 1];
+        double l3d = dim3d[q * 3 + 2] + cls_mean_size[cls * 3 + 2];
+
+        // 3D location: project the (cx, cy) anchor through the calibration.
+        const double x3d = bcx * orig_w;
+        const double y3d = bcy * orig_h;
+        const double X = ((x3d - cu) * depth_val) / fu + tx;
+        double Y = ((y3d - cv) * depth_val) / fv + ty;
+        const double Z = depth_val;
+        Y += h3d / 2.0; // move from 3D center to bottom-center (KITTI convention)
+
+        // heading -> ry. Uses the 2D box center x (in pixels), NOT the 3D anchor.
+        const double alpha = getHeadingAngle(angle + q * 24);
+        const double u_ry = ((x1n + x2n) / 2.0) * orig_w;
+        const double ry = alpha + std::atan2(u_ry - cu, fu);
+
+        const std::string label = getLabels().empty() ? std::string() : getLabelByLabelId(cls);
+
+        // ROI is stored normalized (top-left + size) relative to the full frame.
+        DetectedObject object(x1n, y1n, x2n - x1n, y2n - y1n, 0.0, score, cls, label, 1.0, 1.0, false);
+        object.extra_params_json = buildExtraParamsJson(X, Y, Z, l3d, w3d, h3d, ry);
+        objects.push_back(std::move(object));
+    }
+}
+
+TensorsTable Mono3DConverter::convert(const OutputBlobs &output_blobs) {
+    ITT_TASK(__FUNCTION__);
+    try {
+        InferenceBackend::OutputBlob::Ptr logits_blob, boxes_blob, dim_blob, depth_blob, angle_blob;
+
+        // First pass: resolve unambiguous outputs by last-dim, and logits/dim by name.
+        for (const auto &it : output_blobs) {
+            const auto &blob = it.second;
+            if (!blob)
+                continue;
+            const auto &dims = blob->GetDims();
+            if (dims.size() < 2)
+                continue;
+            const size_t last = dims.back();
+            const std::string name = toLower(it.first);
+
+            if (last == 6)
+                boxes_blob = blob;
+            else if (last == 2)
+                depth_blob = blob;
+            else if (last == 24)
+                angle_blob = blob;
+            else if (name.find("logit") != std::string::npos)
+                logits_blob = blob;
+            else if (name.find("dim") != std::string::npos || name.find("size") != std::string::npos)
+                dim_blob = blob;
+        }
+
+        if (!logits_blob || !dim_blob) {
+            throw std::runtime_error(
+                "mono3d: could not identify 'pred_logits' and 'pred_3d_dim' outputs. The exported model must assign "
+                "distinct, recognizable output names (e.g. pred_logits, pred_boxes, pred_3d_dim, pred_depth, "
+                "pred_angle); otherwise the two [B, Q, 3] outputs cannot be disambiguated.");
+        }
+        if (!boxes_blob || !depth_blob || !angle_blob)
+            throw std::runtime_error("mono3d: missing one of the required outputs (boxes[6]/depth[2]/angle[24]).");
+
+        const auto &image_info = getModelInputImageInfo();
+        const size_t batch_size = image_info.batch_size;
+
+        const std::vector<size_t> logits_dims = logits_blob->GetDims();
+        const size_t num_classes = logits_dims.back();
+
+        const Calibration calib = readCalibration();
+        const std::vector<float> cls_mean_size = readClassMeanSizes(num_classes);
+
+        const float *logits = blobData(logits_blob);
+        const float *boxes = blobData(boxes_blob);
+        const float *dim3d = blobData(dim_blob);
+        const float *depth = blobData(depth_blob);
+        const float *angle = blobData(angle_blob);
+
+        const size_t logits_stride = logits_blob->GetSize() / batch_size;
+        const size_t boxes_stride = boxes_blob->GetSize() / batch_size;
+        const size_t dim_stride = dim_blob->GetSize() / batch_size;
+        const size_t depth_stride = depth_blob->GetSize() / batch_size;
+        const size_t angle_stride = angle_blob->GetSize() / batch_size;
+
+        DetectedObjectsTable objects_table(batch_size);
+        for (size_t b = 0; b < batch_size; ++b) {
+            parseOutputs(logits + b * logits_stride, logits_dims, boxes + b * boxes_stride, dim3d + b * dim_stride,
+                         depth + b * depth_stride, angle + b * angle_stride, calib, cls_mean_size, objects_table[b]);
+        }
+
+        return storeObjects(objects_table);
+    } catch (const std::exception &e) {
+        std::throw_with_nested(std::runtime_error("Failed to do mono3d post-processing."));
+    }
+    return TensorsTable{};
+}

--- a/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/mono3d.h
+++ b/src/monolithic/gst/inference_elements/common/post_processor/converters/to_roi/mono3d.h
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (C) 2026 Intel Corporation
+ *
+ * SPDX-License-Identifier: MIT
+ ******************************************************************************/
+
+#pragma once
+
+#include "blob_to_roi_converter.h"
+#include "inference_backend/image_inference.h"
+
+#include <array>
+#include <string>
+#include <vector>
+
+namespace post_processing {
+
+/*
+MonoDETR monocular 3D detection post-processing ("mono3d").
+
+The model has three inputs (image, calibs=KITTI P2 [N,3,4], img_sizes=original (W,H) [N,2]) and
+five outputs. Because OpenVINO's runtime exposes outputs through a name-keyed map, the exported IR
+MUST assign distinct, recognizable names to the outputs. The expected names (substring match) are:
+    pred_logits : [B, Q, num_classes]      classification logits
+    pred_boxes  : [B, Q, 6]                2D box in normalized cxcylrtb
+    pred_3d_dim : [B, Q, 3]                3D size (h, w, l)
+    pred_depth  : [B, Q, 2]                (depth, sigma_raw)
+    pred_angle  : [B, Q, 24]               12 heading-bin logits + 12 residuals
+
+Camera calibration (P2) and the original image size are supplied through the post-processing
+parameters (injected from the gvadetect "intrinsics-file" property). If absent, sensible defaults
+derived from the model input size are used.
+*/
+class Mono3DConverter : public BlobToROIConverter {
+  public:
+    Mono3DConverter(BlobToMetaConverter::Initializer initializer, double confidence_threshold)
+        : BlobToROIConverter(std::move(initializer), confidence_threshold, false, 0.0) {
+    }
+
+    TensorsTable convert(const OutputBlobs &output_blobs) override;
+
+    static std::string getName() {
+        return "mono3d";
+    }
+
+  private:
+    // P2 projection matrix (row-major 3x4) and original image size used for 3D back-projection.
+    struct Calibration {
+        std::array<double, 12> p2; // [fu 0 cu tx; 0 fv cv ty; 0 0 1 0] row-major
+        double orig_width;
+        double orig_height;
+    };
+
+    Calibration readCalibration() const;
+    size_t readTopK() const;
+    std::vector<float> readClassMeanSizes(size_t num_classes) const;
+
+    void parseOutputs(const float *logits, const std::vector<size_t> &logits_dims, const float *boxes,
+                      const float *dim3d, const float *depth, const float *angle, const Calibration &calib,
+                      const std::vector<float> &cls_mean_size, std::vector<DetectedObject> &objects) const;
+};
+
+} // namespace post_processing

--- a/src/monolithic/gst/inference_elements/common/pre_processors.cpp
+++ b/src/monolithic/gst/inference_elements/common/pre_processors.cpp
@@ -51,6 +51,60 @@ InputPreprocessingFunction createSequenceIndexFunction() {
     };
 }
 
+// Feeds the KITTI-style camera projection matrix P2 ([B, 3, 4]) into a model input.
+// The 12 row-major P2 values are taken from the post/pre-processing parameters
+// (populated from the gvadetect "intrinsics-file" property).
+InputPreprocessingFunction createCalibFunction(const GstStructure *params) {
+    std::vector<float> p2(12, 0.0f);
+    // Sensible default: identity-like projection (overwritten when intrinsics are provided).
+    p2[0] = 1.0f;
+    p2[5] = 1.0f;
+    p2[10] = 1.0f;
+
+    GValueArray *arr = nullptr;
+    if (params && gst_structure_get_array(const_cast<GstStructure *>(params), "P2", &arr) && arr) {
+        if (arr->n_values == 12)
+            for (guint i = 0; i < 12; ++i)
+                p2[i] = static_cast<float>(g_value_get_double(g_value_array_get_nth(arr, i)));
+        G_GNUC_BEGIN_IGNORE_DEPRECATIONS
+        g_value_array_free(arr);
+        G_GNUC_END_IGNORE_DEPRECATIONS
+    }
+
+    return [p2](const InputBlob::Ptr &blob) {
+        float *data = reinterpret_cast<float *>(blob->GetData());
+        const auto dims = blob->GetDims();
+        size_t total = 1;
+        for (size_t d : dims)
+            total *= d;
+        // Replicate P2 across the batch dimension.
+        for (size_t i = 0; i < total; ++i)
+            data[i] = p2[i % p2.size()];
+    };
+}
+
+// Feeds the original image size (W, H) into a model input of shape [B, 2].
+InputPreprocessingFunction createImageSizeFunction(const GstStructure *params) {
+    int width = 0;
+    int height = 0;
+    if (params) {
+        gst_structure_get_int(params, "orig_width", &width);
+        gst_structure_get_int(params, "orig_height", &height);
+    }
+
+    return [width, height](const InputBlob::Ptr &blob) {
+        float *data = reinterpret_cast<float *>(blob->GetData());
+        const auto dims = blob->GetDims();
+        size_t total = 1;
+        for (size_t d : dims)
+            total *= d;
+        for (size_t i = 0; i + 1 < total; i += 2) {
+            data[i] = static_cast<float>(width);
+            data[i + 1] = static_cast<float>(height);
+        }
+    };
+}
+
 cv::Mat getTransform(cv::Mat *src, cv::Mat *dst) {
     if (not src or not dst)
         throw std::invalid_argument("Invalid cv::Mat inputs for GetTransform");
@@ -178,6 +232,10 @@ InputPreprocessingFunction getInputPreprocFunctrByLayerType(const std::string &f
         result = createSequenceIndexFunction();
     else if (format == "image_info")
         result = createImageInfoFunction(preproc_params, inference);
+    else if (format == "calib")
+        result = createCalibFunction(preproc_params);
+    else if (format == "img_sizes")
+        result = createImageSizeFunction(preproc_params);
     else
         result = createImageInputFunction(preproc_params, roi);
 

--- a/src/monolithic/inference_backend/image_inference/image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/image_inference.cpp
@@ -31,6 +31,11 @@ std::map<std::string, GstStructure *> ImageInference::GetModelInfoPreproc(const 
     return OpenVINOImageInference::GetModelInfoPreproc(model_file, preproc_config, ov_extension_lib);
 }
 
+std::map<std::string, std::vector<size_t>> ImageInference::GetModelInputShapes(const std::string model_file,
+                                                                               const gchar *ov_extension_lib) {
+    return OpenVINOImageInference::GetModelInputShapes(model_file, ov_extension_lib);
+}
+
 ImageInference::Ptr ImageInference::createImageInferenceInstance(MemoryType input_image_memory_type,
                                                                  const InferenceConfig &config, Allocator *allocator,
                                                                  CallbackFunc callback, ErrorHandlingFunc error_handler,

--- a/src/monolithic/inference_backend/image_inference/openvino/model_api_converters.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/model_api_converters.cpp
@@ -1030,6 +1030,16 @@ std::map<std::string, GstStructure *> get_model_info_postproc(const std::shared_
             GST_INFO("[get_model_info_postproc] iou_threshold: %f", element.second.as<double>());
             g_value_unset(&gvalue);
         }
+        // Number of top scoring predictions to keep (model_api ClassificationModel key).
+        // Used by query-based detectors (e.g. mono3d) to bound the number of decoded objects.
+        if (element.first == "topk") {
+            GValue gvalue = G_VALUE_INIT;
+            g_value_init(&gvalue, G_TYPE_INT);
+            g_value_set_int(&gvalue, element.second.as<int>());
+            gst_structure_set_value(s, "topk", &gvalue);
+            GST_INFO("[get_model_info_postproc] topk: %d", element.second.as<int>());
+            g_value_unset(&gvalue);
+        }
         if (element.first.find("image_threshold") != std::string::npos) {
             GValue gvalue = G_VALUE_INIT;
             g_value_init(&gvalue, G_TYPE_DOUBLE);

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.cpp
@@ -1533,6 +1533,23 @@ std::map<std::string, GstStructure *> OpenVINOImageInference::GetModelInfoPrepro
     return info;
 }
 
+std::map<std::string, std::vector<size_t>> OpenVINOImageInference::GetModelInputShapes(const std::string model_file,
+                                                                                       const gchar *ov_extension_lib) {
+    if (ov_extension_lib && ov_extension_lib[0] != '\0') {
+        OpenVinoNewApiImpl::core().add_extension(ov_extension_lib);
+    }
+    std::shared_ptr<ov::Model> model = OpenVinoNewApiImpl::core().read_model(model_file);
+
+    std::map<std::string, std::vector<size_t>> res;
+    for (const auto &input : model->inputs()) {
+        const auto &partial_shape = input.get_partial_shape();
+        const auto &shape = partial_shape.is_dynamic() ? partial_shape.get_min_shape() : partial_shape.get_shape();
+        const std::string name = input.get_names().size() > 0 ? input.get_any_name() : std::string("input");
+        res.emplace(name, std::vector<size_t>(shape.begin(), shape.end()));
+    }
+    return res;
+}
+
 void OpenVINOImageInference::Flush() {
     ITT_TASK(__FUNCTION__);
 

--- a/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
+++ b/src/monolithic/inference_backend/image_inference/openvino/openvino_image_inference.h
@@ -47,6 +47,9 @@ class OpenVINOImageInference : public InferenceBackend::ImageInference {
     static std::map<std::string, GstStructure *>
     GetModelInfoPreproc(const std::string model_file, const gchar *pre_proc_config, const gchar *ov_extension_lib);
 
+    static std::map<std::string, std::vector<size_t>> GetModelInputShapes(const std::string model_file,
+                                                                          const gchar *ov_extension_lib);
+
     bool IsQueueFull() override;
 
     void Flush() override;

--- a/src/monolithic/inference_backend/include/inference_backend/image_inference.h
+++ b/src/monolithic/inference_backend/include/inference_backend/image_inference.h
@@ -73,6 +73,12 @@ class ImageInference {
     static std::map<std::string, GstStructure *>
     GetModelInfoPreproc(const std::string model_file, const gchar *pre_proc_config, const gchar *ov_extension_lib);
 
+    // Reads the model's input layer names and shapes directly from the model file, before a backend
+    // instance is created. Used to discover auxiliary inputs (e.g. mono3d calib/img_sizes) that need
+    // custom feeding configured at model-build time.
+    static std::map<std::string, std::vector<size_t>> GetModelInputShapes(const std::string model_file,
+                                                                          const gchar *ov_extension_lib);
+
     virtual bool IsQueueFull() = 0;
     virtual void Flush() = 0;
     virtual void Close() = 0;


### PR DESCRIPTION
### Description

Adds support for MonoDETR monocular 3D object detection to DL Streamer by reusing the existing gvadetect element with a new mono3d post-processing converter. The model consumes an image plus camera calibration and the original image size, and produces 2D ROIs annotated with full 3D cuboids (translation, dimensions, orientation).

No new GStreamer element is introduced — gvadetect drives the model, the converter is auto-selected from the model's rt_info (model_type=mono3d), and 3D results flow downstream to gvawatermark3d / gvadeskew via the existing extra_params_json mechanism.

## What's included
- New mono3d converter (converters/to_roi/mono3d.{h,cpp})
  - Subclasses BlobToROIConverter (need_nms=false), decodes the 5 MonoDETR outputs (logits, boxes, 3D dims, depth, angle).
  - Resolves outputs by name (pred_logits, pred_3d_dim) and shape; the two [B,Q,3] outputs are disambiguated by the model's output names.
  - Performs full 3D lift (sigmoid + top-k scoring, 2D box decode, img_to_rect back-projection, bin-based heading → ry), and emits each detection's 3D cuboid as extra_params_json (translation, dimension, Y-axis rotation quaternion).
  
 - Camera-intrinsics handling

    - New intrinsics-file property on gva_base_inference (JSON; same schema as gvawatermark3d — supports intrinsic_matrix 3×3, projection_matrix 3×4, optional image_size).
    - Shared mono3d_calibration.{h,cpp} helper to parse intrinsics and write P2/orig_width/orig_height onto GStreamer structures.

- Auxiliary model-input feeding

    - pre_processors.cpp: new calib and img_sizes input feeders.
    - inference_impl.cpp: auto-detects the MonoDETR calib ([*,3,4]) and img-size ([*,2]) inputs by shape and injects their preprocessing descriptors.
    - New static ImageInference::GetModelInputShapes (OpenVINO backend) to read input shapes before instantiation.

- rt_info / model-proc-free configuration

  - model_api_converters.cpp: added a topk parser branch so query-count can be driven from rt_info.
  - Calibration is injected into the mono3d post-processor in post_processor.cpp.

