### PR TITLE
build(g3dlidarparse): drop redundant project() call in subdirectory CMakeLists

### DIFF
--- a/src/monolithic/gst/3d_elements/g3dlidarparse/CMakeLists.txt
+++ b/src/monolithic/gst/3d_elements/g3dlidarparse/CMakeLists.txt
@@ -4,9 +4,6 @@
 # SPDX-License-Identifier: MIT
 # ==============================================================================
 
-
-project(g3dlidarparse)
-
 add_library(g3dlidarparse STATIC
     g3dlidarparse.cpp
 )


### PR DESCRIPTION
### Description

Removes the stray `project(g3dlidarparse)` call from
`src/monolithic/gst/3d_elements/g3dlidarparse/CMakeLists.txt`.

### Any Newly Introduced Dependencies

None


### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

