### PR TITLE
fix(g3dlidarparse): correct log message unit from floats to points

### DIFF
--- a/src/monolithic/gst/3d_elements/g3dlidarparse/g3dlidarparse.cpp
+++ b/src/monolithic/gst/3d_elements/g3dlidarparse/g3dlidarparse.cpp
@@ -523,7 +523,8 @@ static GstFlowReturn gst_g3d_lidar_parse_transform(GstBaseTransform *trans, GstB
         filter->next_pts += duration;
     }
 
-    GST_INFO_OBJECT(filter, "Successfully processed lidar buffer with %u floats", lidar_meta->lidar_point_count);
+    GST_INFO_OBJECT(filter, "Successfully processed lidar buffer with %u point%s", lidar_meta->lidar_point_count,
+                    lidar_meta->lidar_point_count == 1 ? "" : "s");
 
     g_mutex_unlock(&filter->mutex);
 


### PR DESCRIPTION
### Description

Fixes a misleading log message in `gst_g3d_lidar_parse_transform` (`src/monolithic/gst/3d_elements/g3dlidarparse/g3dlidarparse.cpp`).
This is a log-text-only change; no behavior, API, or data path is affected.

### Any Newly Introduced Dependencies

None

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

