### PR TITLE
ONVIF: first iteration - split into plugin, library and sample app.

### DIFF
--- a/python/dlstreamer/onvif-plugin/README.md
+++ b/python/dlstreamer/onvif-plugin/README.md
@@ -1,0 +1,921 @@
+# `dlsonvif` — ONVIF Device Provider plugin for GStreamer
+
+This directory contains a GStreamer plugin that registers a
+`Gst.DeviceProvider` named **`onvifdeviceprovider`** (class
+`Source/Network/ONVIF`). The implementation is in Python; a thin C shim
+ensures the feature lands in GStreamer's persistent registry cache and
+is visible to pure-C tools (`gst-device-monitor-1.0`,
+`gst-inspect-1.0`, etc.).
+
+## What is provided
+
+| File | Role |
+|---|---|
+| `c/onvifdeviceprovider_shim.c` | C plugin source |
+| `libgstdlsonvif.so` | Compiled plugin (GStreamer name: `dlsonvif`) |
+| `python/onvifdeviceprovider.py` | `OnvifDeviceProvider` / `OnvifDevice` implementation |
+| `python/dls_onvif_src.py` | Separate `dlsonvifsrc_py` element (loaded by `libgstpython`) |
+
+The `dlsonvif` plugin exposes **1 feature** (`onvifdeviceprovider`).
+The second pipeline-relevant feature (`dlsonvifsrc_py`) is registered by
+the `python` plugin (`libgstpython`) from the file
+`python/dls_onvif_src.py`. For a full reference of all ONVIF-related
+features seen in `gst-inspect-1.0` — see the
+[Feature reference](#feature-reference) section below.
+
+## Feature reference
+
+This section describes every `Gst*Factory` returned by:
+
+```bash
+gst-inspect-1.0 2>&1 | grep -i onvif
+# dlsonvif:  onvifdeviceprovider (GstDeviceProviderFactory)
+# python:    dlsonvifsrc_py: DLS ONVIF Source Python
+# rtponvif:  rtponvifparse: ONVIF NTP timestamps RTP extension
+# rtponvif:  rtponviftimestamp: ONVIF NTP timestamps RTP extension
+```
+
+Full technical documentation of each of the four features: GObject
+header, hierarchy, threading, on-the-wire data format, lifecycle, error
+paths, and operating modes.
+
+### 1. `dlsonvif` → `onvifdeviceprovider` (GstDeviceProviderFactory)
+
+**Type:** `Gst.DeviceProvider` — **not** a pipeline element (not usable
+with `gst-launch`, invisible to `gst-inspect-1.0 <feature>` without the
+plugin name). Implementation: [python/onvifdeviceprovider.py](python/onvifdeviceprovider.py),
+loaded via the C shim [c/onvifdeviceprovider_shim.c](c/onvifdeviceprovider_shim.c)
+into `libgstdlsonvif.so`.
+
+| Field | Value |
+|---|---|
+| Factory name | `onvifdeviceprovider` |
+| Long name | `ONVIF Device Provider` |
+| Classification | `Source/Network/ONVIF` |
+| Rank | `PRIMARY` (256) |
+| Plugin | `dlsonvif` (`libgstdlsonvif.so`, license MIT, package `dlstreamer`) |
+| Author | Intel DLStreamer |
+| GObject hierarchy | `OnvifDeviceProvider → GstDeviceProvider → GstObject → GInitiallyUnowned → GObject` |
+| Device class | `OnvifDevice → GstDevice → GstObject → GInitiallyUnowned → GObject` |
+
+**What it provides.** A stream of `DEVICE_ADDED` / `DEVICE_CHANGED` /
+`DEVICE_REMOVED` notifications on the bus of any `Gst.DeviceMonitor`
+with a `Source/Network/ONVIF` filter, where each event carries a fully
+synchronized representation of an ONVIF camera (XAddr, capabilities,
+media profiles, auth-status). Each device can build a configured
+`rtspsrc` on its own (`do_create_element`), allows re-injecting
+credentials without recreating the element (`do_reconfigure_element`),
+and accepts the `onvif-set-credentials` custom event as a mechanism for
+passing a password from the application to the provider.
+
+#### 1.1. What it uses (runtime dependencies)
+
+- `python-onvif-zeep` (SOAP, optionally `lxml` + `zeep`) — via the
+  internal `dlstreamer.onvif` package (classes `DlsOnvifDiscoveryEngine`,
+  `discover_onvif_cameras`).
+- `requests` — HTTP transport for SOAP.
+- `gi` / `PyGObject` — GStreamer/GObject bindings.
+- `ctypes` — direct calls into `libgstreamer-1.0.so.0` /
+  `libgobject-2.0.so.0`, because PyGObject **does not export**
+  `gst_device_provider_class_set_metadata` nor a way to register a
+  device provider from Python. Registration is implemented manually in
+  `register_provider()` / `register_provider_with_plugin()` via
+  `gst_plugin_register_static_full` with a C callback held as a
+  module-global CFUNCTYPE reference (`_PLUGIN_INIT_REF`), so the GC does
+  not free it during the registry's lifetime.
+- Network: **UDP multicast 239.255.255.250:3702** (WS-Discovery `Probe`),
+  **TCP** to `host:port/onvif/device_service` (SOAP), and a local
+  short-lived **HTTP server** in push-event mode (outside this
+  feature — see the sample-app).
+
+#### 1.2. Threading
+
+Each provider instance maintains:
+
+| Thread | Created in | Function |
+|---|---|---|
+| `onvifdeviceprovider-discover` (daemon) | `do_start()` | Discovery loop: `_discovery_loop` → `_probe_once` every `_probe_interval` seconds (default 30 s, override env `ONVIF_PROVIDER_PROBE_INTERVAL`). Sleeps in 0.5-second chunks so `do_stop()` can wake it within under 0.5 s. |
+| PullPoint workers (per camera, phase 5) | registered in `self._event_workers: dict[str, (Thread, Event)]` | Best-effort subscription to ONVIF Profile S §7.7.4 events (CreatePullPointSubscription + PullMessages, timeout `PT30S`). |
+
+Synchronization: a `threading.RLock()` protecting `self._devices`,
+`self._credentials`, `self._auth_status`, `self._event_workers`. A
+`threading.Event()` is used as the stop-signal for the discovery thread
+and for each PullPoint worker.
+
+#### 1.3. Lifecycle (`GstDeviceProvider` vfuncs)
+
+```
+Gst.DeviceMonitor.start()                     [external API]
+  → OnvifDeviceProvider.do_start()
+     → checks _IMPORT_ERROR (is dlstreamer.onvif available?)
+     → spawn `onvifdeviceprovider-discover`
+     → discovery_loop():
+          probe_once() {
+            for cam in discover_onvif_cameras():
+              xaddr = build_xaddr(cam)
+              if xaddr not in self._devices:
+                device = build_device(xaddr, host, port) {
+                  ONVIFCamera(host, port, user, password)   # SOAP client
+                  GetDeviceInformation()                    # manufacturer/model/serial
+                  GetCapabilities({Category: "All"})        # Media/Events/Imaging/PTZ XAddrs
+                  camera_profiles(client) → list[Profile]   # GetProfiles + GetStreamUri
+                  build_caps_from_profiles(profiles)        # Gst.Caps
+                  base_properties(...)                      # Gst.Structure
+                  return OnvifDevice(...)
+                }
+                self.device_add(device)                     # → DEVICE_ADDED on bus
+            for stale in self._devices - seen_xaddrs:
+              self._drop_device(stale)                       # → DEVICE_REMOVED on bus
+          }
+          sleep(_probe_interval) in 0.5 s chunks
+
+Gst.DeviceMonitor.stop()
+  → do_stop():
+     set stop_event
+     join PullPoint workers (timeout 2 s each)
+     join discovery worker (timeout _probe_interval + 5 s)
+     for device in self._devices: self.device_remove(device)
+     self._devices.clear()
+```
+
+Every `build_device` stage is wrapped in `try/except` — a
+**partial failure** (e.g. SOAP `GetDeviceInformation` fails with 401)
+still publishes the device, only with empty metadata and
+`onvif.auth-status="unauthorized"`. Caps may be empty
+(`Gst.Caps.new_empty()`).
+
+#### 1.4. Device properties
+
+`Gst.Device.get_properties()` returns a `Gst.Structure` named
+`onvif-device` containing:
+
+| Key | Type | Source / meaning |
+|---|---|---|
+| `onvif.xaddr` | string | Canonical, stable camera ID — `xaddr`/`full_url` from WS-Discovery, fallback `http://host:port/onvif/device_service`. **Used as the identity key** in all internal dictionaries. |
+| `onvif.host` | string | Hostname/IP extracted from the XAddr. |
+| `onvif.port` | int | ONVIF service port (default 80). |
+| `onvif.scopes` | string | Space-separated scope URIs from WS-Discovery (`onvif://www.onvif.org/…`); empty until enriched. |
+| `onvif.auth-status` | string | Authorization state: `anonymous` (no attempts), `authenticated` (`GetDeviceInformation` OK), `unauthorized` (401/403), `unknown` (device unknown during a set-credentials attempt). |
+| `onvif.manufacturer` | string | `GetDeviceInformation.Manufacturer`, empty if unauthorized. |
+| `onvif.model` | string | as above, `Model`. |
+| `onvif.serial` | string | as above, `SerialNumber`. |
+| `onvif.capabilities` | `Gst.Structure` (`onvif-capabilities`) | Substructure from `GetCapabilities`. |
+
+The `onvif-capabilities` substructure:
+
+| Key | Type | Meaning |
+|---|---|---|
+| `has-media1` | bool | Whether the camera offers Media v1 (`http://…/onvif/media_service`). |
+| `has-media2` | bool | Whether it offers Media2 (reserved; currently always `False`). |
+| `has-events` | bool | Whether it offers the Events service (`tns1:…`). |
+| `has-receiver` | bool | Whether it has a Receiver service. |
+| `media-version` | int | `1` if Media v1, `0` if absent. |
+| `media` / `events` / `imaging` / `ptz` / `analytics` / `device` | nested `Gst.Structure` (`onvif-capability-<name>`) with an `xaddr` field (string) | Service URL of the given category, when present in the `GetCapabilities` response. |
+
+#### 1.5. Caps (`Gst.Device.get_caps()`)
+
+One `Gst.Structure` of type `onvif-profile` per media profile returned
+by `GetProfiles`. Fields:
+
+| Field | Type | Source / description |
+|---|---|---|
+| `media` | string | Always `"video"` (audio/metadata profiles are not emitted in the current impl.). |
+| `encoding-name` | string | `H264` / `H265` / `JPEG` / `MPEG4` — from `profile.vec_encoding`, uppercased. |
+| `width`, `height` | int | `profile.vec_resolution.{width,height}` (only when > 0). |
+| `framerate` | `Gst.Fraction` | `profile.vec_framerate_limit / 1` (round-trip compatible with `rtspsrc.caps`). |
+| `bitrate` | int | `profile.vec_bitrate_limit` in kbit/s (only when > 0). |
+| `profile` | string | `vec_h264_profile` or `vec_mpeg4_profile` (e.g. `"Main"`, `"High"`, `"Baseline"`). |
+| `profile-token` | string | `profile.token` — argument to `GetStreamUri` on the camera side (e.g. `"Profile_1"`). |
+| `stream-uri` | string | Raw RTSP URL from `GetStreamUri` (without credentials). |
+
+No profiles → `Gst.Caps.new_empty()` (the device remains, but
+`do_create_element` returns `None`).
+
+#### 1.6. `do_create_element(name)`
+
+```
+caps = self.get_caps()
+if caps.size == 0: return None
+struct = caps[0]
+stream_uri = struct["stream-uri"]
+if creds := provider.get_credentials(self.xaddr):
+    stream_uri = inject_credentials(stream_uri, *creds)  # rtsp://user:pwd@host…
+element = Gst.ElementFactory.make("rtspsrc", name)
+element["location"] = stream_uri
+element["latency"] = 200                                  # ms, best-effort
+return element
+```
+
+**Only profile #0 is selected**. If the application wants a different
+profile, it must read the caps and build the `rtspsrc` itself from the
+`stream-uri` of the chosen structure (a typical consumer pattern; the
+classic `Gst.Device` API has no "select a profile and give me an
+element").
+
+#### 1.7. `do_reconfigure_element(element)`
+
+Re-injects credentials into the `location` of an existing `rtspsrc`
+(after a password change via `onvif-set-credentials`):
+
+```
+current = element["location"]
+if not current: return False
+if creds := provider.get_credentials(self.xaddr):
+    element["location"] = inject_credentials(current, *creds)
+return True
+```
+
+The element must be in the `NULL` or `READY` state (rtspsrc requires a
+location remount). The wrapper does not enforce this.
+
+#### 1.8. Custom events accepted by the device
+
+`OnvifDevice.send_event(event)` (overrides `Gst.Device.send_event`,
+which does not exist in GStreamer C — this API is shimmed here for the
+`onvifcm` library):
+
+| Structure | Required fields | Format | Effect |
+|---|---|---|---|
+| `onvif-set-credentials` | `uri` (string) | `onvif://<user>[:<password>]@<host>[:<port>]` (URL-encoded per RFC 3986; `%21` for `!`, etc.) | 1. `urlparse(uri)`, validation of the scheme and the presence of `username`. 2. Store `(user, password)` in `self._credentials[xaddr]`. 3. `_verify_credentials(host, port, user, password)` → SOAP `GetDeviceInformation` (default zeep timeout). 4. Update `onvif.auth-status` (`authenticated`/`unauthorized`). 5. `_refresh_device(xaddr)` → `device_remove(old)` + `device_add(new)` with refreshed properties and caps. |
+
+Return value of `send_event`: `True` if `GetDeviceInformation` succeeded
+(authorization OK), `False` for an invalid URI or an unauthorized
+camera.
+
+#### 1.9. ONVIF events on the monitor bus (phase 5)
+
+Per camera, an optional worker is started that subscribes to the ONVIF
+Events Service (Profile S §7.7.4, PullPoint pattern). Events are mapped
+to the structure:
+
+| Structure | Fields | Type |
+|---|---|---|
+| `onvif-event` | `topic` | string (`tns1:VideoSource/MotionAlarm`, `tns1:RuleEngine/...`) |
+|  | `utc-time` | guint64 (NTP-style, or epoch in ns depending on implementation) |
+|  | `source` | string (`source.name` from the `NotificationMessage`) |
+|  | `data` | string (serialized payload) |
+
+Default PullMessages timeout: `PT30S` (`_DEFAULT_PULLPOINT_TIMEOUT`).
+Workers are **best-effort** — a subscription failure does not break
+discovery and does not publish a device error.
+
+#### 1.10. Logging and diagnostics
+
+- Debug channel: the `[onvifdeviceprovider]` prefix on all
+  `Gst.info/debug/warning/error` calls (the `_gst_log` helper).
+- A Python `Gst.DeviceProvider` **has no direct access to the bus**, so
+  errors are routed to `Gst.error()` — consumers catch them via
+  `GST_DEBUG=onvifdeviceprovider:5`.
+- C shim logs: the `onvifshim` category (`GST_DEBUG=onvifshim:5`).
+
+#### 1.11. Provider properties
+
+**None** — configuration is via environment variables:
+
+| ENV | Default | Effect |
+|---|---|---|
+| `ONVIF_PROVIDER_PROBE_INTERVAL` | `30.0` (s) | WS-Discovery re-probe interval. `≤ 0` = single-shot (one probe, thread ends). |
+| `ONVIFCM_PLUGIN_PATH` | — | Additional path for `libgstpython` / `libgstdlsonvif.so` (scanned by `onvifcm`). |
+| `GST_DEBUG` | — | Typically: `onvifdeviceprovider:5,onvifshim:5`. |
+
+#### 1.12. Registration: two paths
+
+| Function | Called by | Cache persistence |
+|---|---|---|
+| `register_provider()` | `dlstreamer.onvif.__init__` (in-process; e.g. `onvifcm`) — internally `gst_plugin_register_static_full` with a dummy plugin `"onvifdeviceprovider"`. | **NO** — a static plugin has no file on disk, so `gst_registry_save` does not persist it; visible in-process only. |
+| `register_provider_with_plugin(plugin_addr)` | C shim `libgstdlsonvif.so` — `plugin_init()` → a Python call with a `GstPlugin*` converted via ctypes. | **YES** — the feature is linked into a real on-disk plugin → an entry in the binary registry cache → visible to `gst-inspect-1.0`, `gst-device-monitor-1.0`. |
+
+The detection of which path to take is in
+`c/onvifdeviceprovider_shim.c` (it checks `/proc/self/comm` to avoid
+registering in-process inside the `gst-plugin-scanner` subprocess).
+
+#### 1.13. Inspection
+
+```bash
+# plugin name (not the feature):
+gst-inspect-1.0 dlsonvif
+
+# typical usage:
+gst-device-monitor-1.0 -f Source/Network/ONVIF --follow
+
+# in Python:
+Gst.Registry.get().find_feature("onvifdeviceprovider", Gst.DeviceProviderFactory)
+```
+
+---
+
+### 2. `python` → `dlsonvifsrc_py` (GstElementFactory)
+
+**Type:** `Gst.Bin` (a container with a single ALWAYS src pad).
+Implementation: [python/dls_onvif_src.py](python/dls_onvif_src.py);
+registered by the upstream `python` plugin (`libgstpython.so`) —
+**not** by our C shim. Registration mechanism: the module-level variable
+`__gstelementfactory__ = ("dlsonvifsrc_py", Gst.Rank.NONE, OnvifSrc)`,
+which `libgstpython` looks for in every `.py` on `GST_PLUGIN_PATH`.
+
+| Field | Value |
+|---|---|
+| Factory name | `dlsonvifsrc_py` |
+| Long name | `DLS ONVIF Source Python` |
+| Classification | `Source/Network` |
+| Rank | `NONE` (0) |
+| Plugin | `python` (`libgstpython.so` from `gst-python`, file `dls_onvif_src.py` on `GST_PLUGIN_PATH`) |
+| Author | Intel DLStreamer |
+| GObject hierarchy | `OnvifSrc → GstBin → GstElement → GstObject → GInitiallyUnowned → GObject` |
+| Internal pipeline | `uridecodebin3 ! videoconvert ! [ghost src]` |
+
+**What it provides.** A single src pad emitting *decoded* `video/x-raw`
+directly from an ONVIF camera, after automatic WS-Discovery and RTSP URL
+resolution via SOAP. The application does not need to build
+`rtspsrc + depayloader + decoder` — `dlsonvifsrc_py ! videoconvert ! <sink>`
+is enough.
+
+#### 2.1. What it uses (runtime dependencies)
+
+- `python-onvif-zeep` + `zeep` + `lxml` — via the internal
+  `dlstreamer.onvif.dls_onvif_discovery_engine` (classes
+  `discover_onvif_cameras`, `DlsOnvifDiscoveryEngine`).
+- `gi` / `PyGObject` — `Gst`, `GObject`.
+- GStreamer element: **`uridecodebin3`** (from `gst-plugins-base` ≥ 1.20)
+  — internally manages the full RTSP pipeline (`rtspsrc` → depay →
+  parser → decoder) together with the jitter buffer.
+- GStreamer element: **`videoconvert`** (from `gst-plugins-base`) —
+  pixel-format conversion to canonical raw video.
+- If the Python dependencies are not available, the module still
+  registers, but discovery mode returns `Gst.StateChangeReturn.FAILURE`
+  with `[dlsonvifsrc_py] dlstreamer.onvif unavailable: <ImportError>`.
+  The `rtsp-uri` (override) mode works **without** the ONVIF
+  dependencies.
+
+#### 2.2. Network
+
+- **In discovery mode:** UDP multicast 239.255.255.250:3702 (Probe),
+  TCP `host:port/onvif/device_service` (SOAP `GetProfiles` + `GetStreamUri`),
+  then RTSP (TCP/UDP per `rtspsrc` negotiation).
+- **In override mode (`rtsp-uri`):** RTSP only.
+
+#### 2.3. Threading
+
+The element creates no auxiliary threads of its own — discovery happens
+**synchronously** in `do_change_state(NULL → READY)` and blocks for the
+duration of `discovery-timeout` (default 5 s). Afterwards all real-time
+operations run in `uridecodebin3` threads.
+
+#### 2.4. Pad templates
+
+| Name | Direction | Presence | Caps template | Actual caps |
+|---|---|---|---|---|
+| `src` | SRC | ALWAYS | `ANY` | `video/x-raw, format=I420/NV12/RGB/…` after `videoconvert` (auto-negotiated with downstream) |
+
+Sink pads — none (it is a source). The internal `uridecodebin3` has
+dynamic pads, connected by the `pad-added` handler
+(`_on_uridecodebin_pad_added`) — **only the first pad starting with
+`video/` is linked**; audio and metadata pads are ignored (left
+unlinked).
+
+#### 2.5. Properties
+
+| Name | Type | Range | Default | Effect |
+|---|---|---|---|---|
+| `hostname` | string | any | `""` | WS-Discovery filter: only the camera with this hostname/IP. `""` = the first one found. |
+| `port` | int | 0–65535 | `0` | ONVIF port filter. `0` = any port. |
+| `user-id` | string | any | `""` | Username for ONVIF SOAP and RTSP (injected into the URL: `rtsp://user:pwd@host…`). |
+| `user-pw` | string | any | `""` | Password, as above. |
+| `profile-index` | int | 0–64 | `0` | Index of the media profile to stream (0-based). If `>=len(profiles)`, falls back to 0 with the warning `profile-index … out of range`. |
+| `discovery-timeout` | int | 1–60 s | `5` | Timeout (s) for WS-Discovery responses. The probe blocks `do_change_state` for this time. |
+| `rtsp-uri` | string | any URL | `""` | **Override:** if non-empty, discovery and SOAP are skipped and the internal `uridecodebin3` receives this URI directly. Useful for unit tests and when the application knows the URL from another source. |
+| `latency` | int | 0–10000 ms | `200` | `uridecodebin3` latency (RTSP jitter buffer). Skipped (warning `TypeError`) on older `uridecodebin3` versions without this property. |
+
+All properties are **read once** during `NULL → READY` — a change in the
+`PLAYING` state has no effect until the next `READY → NULL → READY`
+cycle.
+
+#### 2.6. Lifecycle (state transitions)
+
+```
+NULL → READY:
+  if rtsp-uri is non-empty:
+    resolved_uri = rtsp-uri
+  else:
+    cam = discover_onvif_cameras(verbose=False)        # 5 s (or `discovery-timeout`)
+    match = first camera matching the hostname/port filter
+    if not match: return FAILURE
+    client = ONVIFCamera(host, port, user, password)
+    profiles = DlsOnvifDiscoveryEngine().camera_profiles(client)
+    profile = profiles[profile-index | 0]
+    rtsp_url = profile.rtsp_url
+    if user and password and "@" not in rtsp_url:
+        rtsp_url = "rtsp://user:pwd@" + rest
+    resolved_uri = rtsp_url
+  uridecodebin3["uri"] = resolved_uri
+  uridecodebin3["latency"] = latency_ms
+
+READY → PAUSED → PLAYING:
+  delegated to GstBin.do_change_state (uridecodebin3 starts the pipeline).
+
+PAUSED → READY → NULL:
+  resolved_uri = None  (re-discovery on the next NULL → READY)
+  delegated to GstBin.
+```
+
+**Re-discovery.** To force another probe (e.g. after a camera
+hot-swap), the application must go through a full
+`set_state(NULL) → set_state(PLAYING)` cycle.
+
+#### 2.7. Signals and events
+
+- **No signals of its own** (`__gsignals__` is empty).
+- Upstream/downstream events are forwarded by `GstBin` without
+  modification.
+- The element **does not consume** `onvif-set-credentials` (that is a
+  device-provider event, not this source's) — credentials are set via
+  the `user-id` / `user-pw` properties.
+
+#### 2.8. Error paths
+
+| Situation | Result |
+|---|---|
+| `dlstreamer.onvif` or `python-onvif-zeep` fail to import | In `NULL → READY` in discovery mode → `Gst.error("dlstreamer.onvif unavailable: …")` and `Gst.StateChangeReturn.FAILURE`. The `rtsp-uri` mode works. |
+| `uridecodebin3` or `videoconvert` missing | In `__init__` → `Gst.error("required GStreamer elements not available")`, the element is non-functional (no src pad). |
+| WS-Discovery found no matching camera | `Gst.error("no ONVIF camera matched the requested filters")` + `FAILURE`. |
+| `ONVIFCamera(host, port, user, password)` raises | `Gst.error("ONVIF connect to host:port failed: …")` + `FAILURE`. |
+| `GetProfiles` raises or returns an empty list | `Gst.error(...)` + `FAILURE`. |
+| Profile without `rtsp_url` | `Gst.error("profile 'X' has no RTSP URL")` + `FAILURE`. |
+| `uridecodebin3 → videoconvert` link failed (unusual) | `Gst.error("failed to link uridecodebin3 -> videoconvert: …")`, the pad will not be linked — the bin emits no data. |
+
+#### 2.9. Logging
+
+All element messages carry the `[dlsonvifsrc_py]` prefix. Enable:
+
+```bash
+GST_DEBUG=2,*onvif*:6,uridecodebin3:5 gst-launch-1.0 dlsonvifsrc_py ! fakesink
+```
+
+#### 2.10. Examples
+
+```bash
+# Discovery + autoplay of the first camera found (anonymously):
+gst-launch-1.0 dlsonvifsrc_py discovery-timeout=2 ! videoconvert ! fakesink
+
+# Specific camera + credentials + second profile:
+gst-launch-1.0 dlsonvifsrc_py hostname=10.91.106.215 port=8080 \
+    user-id=admin user-pw=Secret profile-index=1 latency=300 \
+  ! videoconvert ! autovideosink
+
+# Override (no WS-Discovery and no SOAP):
+gst-launch-1.0 dlsonvifsrc_py rtsp-uri=rtsp://10.91.106.215:8554/cam0_main \
+  ! videoconvert ! autovideosink
+
+# Python:
+import gi; gi.require_version("Gst", "1.0")
+from gi.repository import Gst
+Gst.init(None)
+pipeline = Gst.parse_launch(
+    "dlsonvifsrc_py hostname=10.91.106.215 user-id=admin user-pw=Secret "
+    "! videoconvert ! autovideosink"
+)
+pipeline.set_state(Gst.State.PLAYING)
+```
+
+#### 2.11. Inspection
+
+```bash
+gst-inspect-1.0 dlsonvifsrc_py
+# shows long-name, classification, pad templates, list of properties
+```
+
+---
+
+### 3. `rtponvif` → `rtponvifparse` (GstElementFactory)
+
+**Type:** an upstream `GstElement` from `gst-plugins-bad` (Axis
+Communications / Collabora, **not** owned by this repo —
+[gst/onvif/gstrtponvifparse.c](../../../build/deps/gstreamer/src/gstreamer/subprojects/gst-plugins-bad/gst/onvif/gstrtponvifparse.c)).
+A **receiving** element (depacketization side): it extracts the absolute
+UTC time and status flags from the ONVIF RTP header extension in the
+stream coming from a camera (Profile G replay / Profile S with precise
+timestamps).
+
+| Field | Value |
+|---|---|
+| Factory name | `rtponvifparse` |
+| Long name | `ONVIF NTP timestamps RTP extension` |
+| Classification | `Effect/RTP` |
+| Rank | `NONE` (0) |
+| Plugin | `rtponvif` (`libgstrtponvif.so`, gst-plugins-bad, `description="ONVIF Streaming features"`) |
+| Author | Guillaume Desmottes \<guillaume.desmottes@collabora.com\> (Collabora) |
+| License | LGPL 2.1 |
+| GObject hierarchy | `GstRtpOnvifParse → GstElement → GstObject → GInitiallyUnowned → GObject` |
+
+#### 3.1. What it provides
+
+For each RTP buffer:
+
+1. **Parses the ONVIF RTP header extension** with ID `0xABAC`, length
+   `EXTENSION_SIZE = 3` words (3 × 32-bit = 12 bytes of extension
+   payload). If the extension is missing or has a different ID/length,
+   the buffer is passed through unchanged.
+2. **Sets `GST_BUFFER_PTS`** to the absolute time computed from the
+   64-bit NTP timestamp (seconds + fraction since the 1900-01-01 UTC
+   epoch). If the timestamp is `0xFFFFFFFF:0xFFFFFFFF` (the "unknown"
+   value) → `GST_BUFFER_PTS = GST_CLOCK_TIME_NONE`.
+3. **Translates the status flags** into `GstBuffer` flags (see §3.4).
+4. **On the `T` flag** (termination) — sends `GST_EVENT_EOS` on the src
+   pad *after* pushing the buffer and returns `GST_FLOW_EOS`.
+
+The element does not change the payload data (caps `application/x-rtp`
+→ `application/x-rtp`), `GST_PAD_SET_PROXY_CAPS` on the sink pad.
+
+#### 3.2. What it uses
+
+- `gst/rtp/gstrtpbuffer.h` — `gst_rtp_buffer_map(GST_MAP_READWRITE)` +
+  `gst_rtp_buffer_get_extension_data()` to read the extension header.
+- No network dependencies of its own — it works only on buffers from
+  upstream.
+
+#### 3.3. Pad templates
+
+| Name | Direction | Presence | Caps |
+|---|---|---|---|
+| `sink` | SINK | ALWAYS | `application/x-rtp` (PROXY_CAPS) |
+| `src` | SRC | ALWAYS | `application/x-rtp` |
+
+Chain function: `gst_rtp_onvif_parse_chain` (per-buffer; no chain-list).
+
+#### 3.4. ONVIF RTP header extension format (`0xABAC`)
+
+Per the ONVIF Streaming Spec. After the standard RTP header extension
+header (`defined-by-profile=0xABAC`, `length=3`), 12 bytes follow:
+
+```
+ 0                   1                   2                   3
+ 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|            NTP timestamp, seconds (32 bit, big-endian)        |  data[0..3]
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|           NTP timestamp, fraction (32 bit, big-endian)        |  data[4..7]
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|C|E|D|T|  mbz  |     CSeq      |          reserved (mbz)        |  data[8..11]
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+| Bit (in `data[8]`) | Mask | Name | Mapping in `rtponvifparse` |
+|---|---|---|---|
+| 7 | `1<<7` | **C** — Clean point (key frame / IDR) | set → `GST_BUFFER_FLAG_UNSET(DELTA_UNIT)`; unset → `SET(DELTA_UNIT)`. |
+| 6 | `1<<6` | **E** — End of contiguous recording | currently *read but not handled* (`TODO` in the code). |
+| 5 | `1<<5` | **D** — Discontinuity | set → `GST_BUFFER_FLAG_SET(DISCONT)`; unset → `UNSET(DISCONT)`. |
+| 4 | `1<<4` | **T** — Termination (end of stream) | set → after pushing the buffer sends `EOS` and returns `GST_FLOW_EOS`. |
+
+Time conversion: `pts_ns = seconds * GST_SECOND + (fraction * 1e9 >> 32) * GST_NSECOND`.
+`data[9]` = low byte of CSeq (currently read, `TODO` — unused).
+
+#### 3.5. Position in the pipeline
+
+**Directly after** `rtspsrc` / `rtpbin` / the RTP session manager,
+**before** the depayloader (`rtph264depay`, `rtph265depay`, …). The
+header extension is part of the RTP, not the payload — the depayloader
+would lose it.
+
+#### 3.6. Error paths
+
+| Situation | Result |
+|---|---|
+| `gst_rtp_buffer_map` failed | `GST_ELEMENT_ERROR(STREAM, FAILED, "Failed to map RTP buffer")`, `GST_FLOW_ERROR`, buffer freed. |
+| Missing extension or wrong ID/length | Buffer passed through unchanged (no-op). |
+| Push to src failed | The error code from `gst_pad_push` is returned. |
+
+#### 3.7. Example
+
+```bash
+gst-launch-1.0 rtspsrc location=rtsp://cam/onvif !            \
+    rtponvifparse ! rtph264depay ! h264parse ! avdec_h264 !   \
+    videoconvert ! autovideosink
+```
+
+---
+
+### 4. `rtponvif` → `rtponviftimestamp` (GstElementFactory)
+
+**Type:** an upstream `GstElement` from `gst-plugins-bad` (as above,
+[gst/onvif/gstrtponviftimestamp.c](../../../build/deps/gstreamer/src/gstreamer/subprojects/gst-plugins-bad/gst/onvif/gstrtponviftimestamp.c)).
+The **inverse** of `rtponvifparse` (packetization / sender side): on the
+RTSP **server** side (typically inside `gst-rtsp-server` in ONVIF replay
+mode) it injects the `0xABAC` header extension with the UTC time and the
+C/E/D/T flags into every RTP packet. Used when implementing a
+**Profile G replay endpoint** or a custom Profile S server with a
+precise send time.
+
+| Field | Value |
+|---|---|
+| Factory name | `rtponviftimestamp` |
+| Long name | `ONVIF NTP timestamps RTP extension` |
+| Classification | `Effect/RTP` |
+| Rank | `NONE` (0) |
+| Plugin | `rtponvif` (`libgstrtponvif.so`, gst-plugins-bad) |
+| Author | Guillaume Desmottes (Collabora) |
+| License | LGPL 2.1 |
+| GObject hierarchy | `GstRtpOnvifTimestamp → GstElement → GstObject → GInitiallyUnowned → GObject` |
+| Debug category | `rtponviftimestamp` |
+
+#### 4.1. What it provides
+
+For each buffer (or `GstBufferList`):
+
+1. `gst_rtp_buffer_set_extension_data(0xABAC, 3)` — allocates a
+   12-byte ONVIF extension in the RTP header.
+2. Writes the **64-bit NTP timestamp** (big-endian) from the buffer's
+   UTC time (`GST_WRITE_UINT64_BE`). Conversion:
+   `ntp = utc_ns * (1<<32) / GST_SECOND`.
+3. Sets the C/E/D/T status bits (`data[8]`) per the rules in §4.5.
+4. Writes the low byte of `cseq` into `data[9]`, zeroes `data[10..12]`.
+
+#### 4.2. What it uses
+
+- `gst/rtp/gstrtpbuffer.h` — `gst_rtp_buffer_set_extension_data()` +
+  `gst_rtp_buffer_get_extension_data()`.
+- `GstReferenceTimestampMeta` with caps `timestamp/x-unix` — the
+  `use-reference-timestamps` mode (adds the constant `2208988800 s` =
+  the UNIX↔NTP epoch difference, in nanoseconds).
+- `GstSegment` (`GST_FORMAT_TIME`) — required to translate
+  `GST_BUFFER_PTS/DTS` into stream-time
+  (`gst_segment_to_stream_time_full`) in `ntp-offset` mode. Without a
+  time segment → `GST_ELEMENT_ERROR("did not receive a time segment
+  yet")`.
+- `gst_element_get_clock()` + `g_get_real_time()` — auto-computation of
+  `ntp-offset` when it is not set explicitly and reference-meta is not
+  used.
+
+#### 4.3. Pad templates
+
+| Name | Direction | Presence | Caps |
+|---|---|---|---|
+| `sink` | SINK | ALWAYS | `application/x-rtp` (PROXY_CAPS, PROXY_ALLOCATION) |
+| `src` | SRC | ALWAYS | `application/x-rtp` |
+
+Chain functions: `gst_rtp_onvif_timestamp_chain` (per-buffer) **and**
+`gst_rtp_onvif_timestamp_chain_list` (a custom chain-list
+implementation, to avoid copying every buffer —
+`gst_pad_chain_list_default` refs buffers, making them non-writable).
+
+#### 4.4. Properties
+
+| Name | Type | Range | Default | Mutability | Description |
+|---|---|---|---|---|---|
+| `ntp-offset` | guint64 | `0 … G_MAXUINT64` | `0xFFFFFFFFFFFFFFFF` (`-1`, auto) | READWRITE | Offset between the pipeline running-time and absolute UTC, in **ns since 1900-01-01**. `-1` = the element computes it from `clock_time` and `g_get_real_time()` on the first buffer (requires a clock — in `PAUSED` without a clock the error "Can not guess ntp-offset" is raised). |
+| `cseq` | guint | `0 … G_MAXUINT32` | `0` | READWRITE | The `CSeq` of the RTSP `PLAY` request that started the playback. The low byte is copied into `data[9]` of every extension. Profile G replay. |
+| `set-e-bit` | gboolean | — | `false` | READWRITE | Set the **E** bit (end of a contiguous recording segment) in the **last** buffer of the segment. Requires caching one element → **+1 packet of latency**. |
+| `set-t-bit` | gboolean | — | `false` | READWRITE | Set the **T** bit (termination) in the last buffer after `EOS`. **+1 packet of latency**. |
+| `drop-out-of-segment` | gboolean | — | `true` | READWRITE | Drop buffers outside the `GstSegment` (beyond the spec — enables full reverse playback). When `false`, a buffer without a valid stream-time is still sent (without a timestamp). |
+| `use-reference-timestamps` | gboolean | — | `false` | READWRITE + **MUTABLE_READY** (Since 1.22) | Take UTC from `GstReferenceTimestampMeta` (`timestamp/x-unix`) instead of the `ntp-offset` mechanism. Required when the source already has accurate UTC (e.g. a PTP camera). If set **and** `ntp-offset` is explicit → a warning and `ntp-offset` is zeroed. |
+
+#### 4.5. Bit-setting rules (`data[8]` = `C E D T mbz`)
+
+| Bit | Mask | Set condition |
+|---|---|---|
+| **C** | `1<<7` | The buffer does **not** have `GST_BUFFER_FLAG_DELTA_UNIT` (i.e. it is a key frame / clean point). |
+| **E** | `1<<6` | `last == TRUE` (last buffer of the segment/list) **and** `self->set_e_bit` (set by `EOS` or the custom `GstOnvifTimestamp` event with `discont=TRUE`). Reset after use. |
+| **D** | `1<<5` | `self->set_d_bit` (after `READY→PAUSED`, `FLUSH_STOP`, or an ntp-offset event with `discont=TRUE`) **or** the buffer has `GST_BUFFER_FLAG_DISCONT`. Reset after use. |
+| **T** | `1<<4` | `last == TRUE` **and** `self->set_t_bit` (set by `EOS` when `prop_set_t_bit`). Reset after use. |
+
+#### 4.6. Events
+
+| Event | Handling |
+|---|---|
+| `GST_EVENT_SEGMENT` | Copied into `self->segment` (`gst_event_copy_segment`); must be `GST_FORMAT_TIME` for `ntp-offset` mode. |
+| `GST_EVENT_EOS` | Forces `set_e_bit=TRUE` (+ `set_t_bit` if `prop_set_t_bit`), pushes the cached buffer and the event queue. |
+| `GST_EVENT_FLUSH_STOP` | Clears the cache, `set_d_bit=TRUE`, resets `e/t`, reinitializes the segment. |
+| `GST_EVENT_CUSTOM_DOWNSTREAM` named `GstOnvifTimestamp` | Contains the fields `ntp-offset` (clock-time) and `discont` (bool). Updates `self->ntp_offset` and `set_d_bit`; in `set-e-bit` mode it may mark the cached buffer as the end of the segment. The event is **consumed** (dropped). |
+
+Serialized events arriving while a cached buffer exists are
+**queued** (`event_queue`) and sent after the buffer is pushed.
+
+#### 4.7. Lifecycle (`change_state`)
+
+```
+READY → PAUSED:
+  if use-reference-timestamps && ntp-offset explicit: warning, ntp_offset = NONE
+  elif use-reference-timestamps: reference-meta mode
+  else: ntp_offset = prop_ntp_offset
+  set_d_bit = TRUE; set_e_bit = FALSE; set_t_bit = FALSE
+PAUSED → READY:
+  purge_cached_buffer_and_events(); gst_segment_init(UNDEFINED)
+```
+
+#### 4.8. Caching and latency
+
+When `set-e-bit` or `set-t-bit` is active, the element **holds one
+buffer/list in the cache** (`self->buffer` / `self->list`) so it knows
+which element is last in the segment → hence **+1 packet of latency**.
+Without these flags, buffers are modified and sent immediately (zero
+extra latency).
+
+#### 4.9. Position in the pipeline
+
+**After** the payloader (`rtph264pay`, `rtph265pay`, …), **before** the
+RTP/UDP sink (`udpsink`) or in the `pay0` factory of
+`gst-rtsp-server`. Works on `application/x-rtp`.
+
+#### 4.10. Error paths
+
+| Situation | Result |
+|---|---|
+| No clock in `PAUSED` with auto `ntp-offset` | `GST_ELEMENT_ERROR(STREAM, FAILED, "Can not guess ntp-offset with no clock")`. |
+| No time segment | `GST_ELEMENT_ERROR(STREAM, FAILED, "did not receive a time segment yet")`. |
+| `set/get_extension_data` failed | `GST_ELEMENT_ERROR(STREAM, FAILED, "Failed to set/get extension data")`. |
+| `use-reference-timestamps` but no meta on the buffer | `GST_ERROR("UTC reference timestamp not found")`, `time=NONE`; with `drop-out-of-segment=true` → `FALSE`/error. |
+
+#### 4.11. Example (replay-server fragment)
+
+```bash
+# inside the media factory of gst-rtsp-server (pay0 launch string):
+( filesrc location=clip.mkv ! matroskademux ! h264parse !       \
+  rtph264pay name=pay0 pt=96 !                                  \
+  rtponviftimestamp set-e-bit=true set-t-bit=true cseq=42 )
+
+# with an explicit ntp-offset (ns since 1900) instead of auto:
+... ! rtph264pay ! rtponviftimestamp ntp-offset=16780000000000000000 ! udpsink
+
+# a source with accurate UTC (PTP) — reference-timestamp meta:
+... ! rtph264pay ! rtponviftimestamp use-reference-timestamps=true ! udpsink
+```
+
+#### 4.12. Inspection
+
+```bash
+gst-inspect-1.0 rtponvifparse
+gst-inspect-1.0 rtponviftimestamp
+gst-inspect-1.0 rtponvif          # the whole plugin: both elements
+```
+
+## Requirements
+
+- GStreamer ≥ 1.20 with `libgstpython` (gst-python)
+- Python 3.10+ with `gi` / `PyGObject`
+- Python packages: `python-onvif-zeep` (or compatible), `zeep`,
+  `requests` (pulled in by `dlstreamer.onvif`)
+- A C compiler (`gcc` / `clang`) + `pkg-config` + `python3-config`
+
+## Building the shim
+
+```bash
+./scripts/build_onvif_shim.sh
+# → python/dlstreamer/onvif-plugin/libgstdlsonvif.so
+```
+
+The script uses `pkg-config gstreamer-1.0` and `python3-config --embed`.
+
+## Running
+
+### Variant A — running from the source tree (recommended during dev)
+
+```bash
+source python3venv/bin/activate
+source scripts/setup_dls_env.sh
+
+export GST_PLUGIN_PATH="$PWD/python/dlstreamer/onvif-plugin:$GST_PLUGIN_PATH"
+export PYTHONPATH="$PWD/python:$PYTHONPATH"
+
+# Clear the registry cache if it was previously built without the shim:
+rm -rf ~/.cache/gstreamer-1.0/
+
+gst-inspect-1.0 dlsonvif
+# → displays the plugin + "1 features: +-- 1 device providers"
+```
+
+The C shim automatically appends its directories to `sys.path`:
+- `<so_dir>/python/` — to find `onvifdeviceprovider.py`
+- `<so_dir>/../../` — to find the `dlstreamer.onvif` package
+
+Thanks to this, in Variant A `PYTHONPATH` is optional for plugin
+loading itself — it is only required for a direct `import
+dlstreamer.onvif` from the application.
+
+### Variant B — system installation
+
+```bash
+# 1. Copy the C plugin into GStreamer's plugin directory:
+sudo cp python/dlstreamer/onvif-plugin/libgstdlsonvif.so \
+        /opt/intel/dlstreamer/gstreamer/lib/gstreamer-1.0/
+
+# 2. Expose the Python module on sys.path (one of the following):
+#    a) copy the whole python/dlstreamer/onvif-plugin/python/ directory to
+#       a known path and set PYTHONPATH permanently, or
+#    b) install `dlstreamer-onvif` as a package into site-packages
+#       (if you have an external distribution), or
+#    c) leave the plugin in the tree (Variant A) and pass GST_PLUGIN_PATH.
+
+# 3. Clear the cache:
+sudo rm -rf ~/.cache/gstreamer-1.0/ /root/.cache/gstreamer-1.0/
+```
+
+After installation, `gst-inspect-1.0 dlsonvif` works in any terminal
+without setting `GST_PLUGIN_PATH`.
+
+## Usage
+
+### `gst-device-monitor-1.0` (pure CLI)
+
+```bash
+gst-device-monitor-1.0 -f Source/Network/ONVIF
+# Probing devices...
+# Monitoring devices, waiting for devices to be removed or new devices to be added...
+# Device found:
+#   name  : <camera friendly name>
+#   class : Source/Network/ONVIF
+#   caps  : onvif-profile, media=video, encoding-name=H264, width=1920, ...
+#   properties:
+#     onvif.host = 192.168.x.y
+#     onvif.port = 80
+#     onvif.xaddr = http://192.168.x.y/onvif/device_service
+#     ...
+#   gst-launch-1.0 rtspsrc location=rtsp://... ! ...
+```
+
+**Important:** use the `-f` / `--follow` flag. Without it,
+`gst-device-monitor-1.0` takes a snapshot immediately after
+`monitor.start()` and ends the process before our WS-Discovery loop
+(~5 s) manages to publish the first device — you will see only
+`Probing devices...` and an empty list.
+
+### `Gst.DeviceMonitor` from Python
+
+```python
+from gi.repository import Gst
+
+Gst.init(None)
+monitor = Gst.DeviceMonitor.new()
+monitor.add_filter("Source/Network/ONVIF", None)
+monitor.start()
+
+for dev in monitor.get_devices():
+    print(dev.get_display_name(), "→", dev.get_properties().to_string())
+
+monitor.stop()
+```
+
+### The `onvifcm` library
+
+```python
+import onvifcm
+
+onvifcm.init_discovery()
+onvifcm.start_discovery()
+for cam in onvifcm.list_discovered_cameras():
+    print(cam)
+```
+
+`import dlstreamer.onvif` is performed indirectly by `onvifcm` and
+auto-registers the provider in-process (in-process static plugin),
+independently of the C shim.
+
+### Passing credentials to a camera
+
+The provider emits devices without injected credentials in
+`device.launch_line` (hostname/port only). To pass a username and
+password, send a custom event to the `rtspsrc` element (or to the
+`Gst.Device` itself before `create_element()`):
+
+```python
+s = Gst.Structure.new_empty("onvif-set-credentials")
+s.set_value("user", "admin")
+s.set_value("password", "1234")
+event = Gst.Event.new_custom(Gst.EventType.CUSTOM_DOWNSTREAM, s)
+device.send_event(event)
+```
+
+## Diagnostics
+
+| Symptom | Most common cause |
+|---|---|
+| `No such element or plugin 'dlsonvif'` | `GST_PLUGIN_PATH` does not point to the directory with `libgstdlsonvif.so`, or the registry cache is stale — clear `~/.cache/gstreamer-1.0/`. |
+| `gst-inspect-1.0 onvifdeviceprovider` → nothing | Expected. `gst-inspect-1.0 <name>` only searches element factories. Use `gst-inspect-1.0 dlsonvif` or `gst-device-monitor-1.0`. |
+| `gst-device-monitor-1.0 Source/Network/ONVIF` shows only `Probing devices...` and exits | Missing the `-f` / `--follow` flag — the tool exits before WS-Discovery (~5 s) manages to publish the devices. |
+| `0 features` in `gst-inspect-1.0 dlsonvif` | In-process auto-registration from `dlstreamer.onvif.__init__` ran inside the scanner subprocess and stole the feature. Check that the `gst-plugin-scanner` detection (`/proc/self/comm`) works. |
+| `undefined symbol: PyTuple_Type` when loading the plugin | The shim did not `dlopen(libpython3.X.so.1.0, RTLD_GLOBAL)` before `Py_Initialize()`. This should be done automatically by `ensure_libpython_global()`. |
+| No devices despite an available camera | A firewall is blocking multicast UDP 3702 (WS-Discovery). Check `iptables`/`ufw`. You can increase the timeout: the `discovery-timeout` property on the provider. |
+
+Enable logs:
+
+```bash
+GST_DEBUG="onvifshim:5,GST_REGISTRY:4,GST_PLUGIN_LOADING:4" \
+  gst-device-monitor-1.0 Source/Network/ONVIF 2>&1 | less
+```
+
+On the Python side, set `GST_DEBUG_NO_COLOR=1` + the regular GStreamer
+logs will show messages from the module (the `onvifdeviceprovider`
+channel).
+
+## Why two plugins?
+
+- **`dlsonvif`** (C shim) — the device provider wrapper. It must be in a
+  `.so`, because GStreamer caches features only from real on-disk
+  plugins; a pure-Python `gst_plugin_register_static_full` is visible
+  in-process only.
+- **`python` / `dls_onvif_src.py`** — a `Gst.Bin` element loaded by the
+  existing `libgstpython`. A different use case (pipeline element), a
+  different registration mechanism (`__gstelementfactory__`).
+
+The C plugin name **must differ** from the feature name
+(`onvifdeviceprovider`), otherwise `gst_registry_add_feature`
+automatically creates a static plugin of the same name and steals the
+registration.

--- a/python/dlstreamer/onvif-plugin/c/onvifdeviceprovider_shim.c
+++ b/python/dlstreamer/onvif-plugin/c/onvifdeviceprovider_shim.c
@@ -1,0 +1,196 @@
+/* ============================================================================
+ * onvifdeviceprovider_shim.c
+ *
+ * Minimal C GStreamer plugin whose only job is to expose the Python-side
+ * ``onvifdeviceprovider`` GstDeviceProvider to gst-inspect-1.0,
+ * gst-device-monitor-1.0 and any other pure-C tool that walks the registry
+ * cache.
+ *
+ * libgstpython only honours ``__gstelementfactory__`` and does not expose
+ * the loading GstPlugin* to Python, so a Gst.DeviceProvider implemented in
+ * Python cannot be persisted into the binary registry by libgstpython
+ * alone. This shim is a normal GST plugin with its own ``GST_PLUGIN_DEFINE``
+ * and filename, so its features are cached correctly. ``plugin_init`` runs
+ * embedded Python, imports ``onvifdeviceprovider`` and calls
+ * ``register_provider_with_plugin(plugin_addr)`` which registers the
+ * Python-backed DeviceProvider against this very plugin.
+ *
+ * Build (see ../scripts/build_onvif_shim.sh):
+ *     gcc -shared -fPIC -O2 -Wall \
+ *         $(pkg-config --cflags --libs gstreamer-1.0) \
+ *         $(python3-config --cflags --ldflags --embed) \
+ *         -o libgstonvifdeviceprovider.so onvifdeviceprovider_shim.c
+ *
+ * Runtime requirements:
+ *   - ``PYTHONPATH`` must let ``import onvifdeviceprovider`` succeed
+ *     (typically the sibling ``python/`` directory plus the project's
+ *     ``python/`` root so ``import dlstreamer.onvif`` resolves).
+ *   - The built ``libgstonvifdeviceprovider.so`` must live somewhere on
+ *     ``GST_PLUGIN_PATH``.
+ * ========================================================================== */
+
+#include <gst/gst.h>
+#include <dlfcn.h>
+#include <libgen.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define PY_SSIZE_T_CLEAN
+#include <Python.h>
+
+GST_DEBUG_CATEGORY_STATIC (onvif_shim_debug);
+#define GST_CAT_DEFAULT onvif_shim_debug
+
+/* Locate the directory containing this very .so and extend sys.path so
+ * ``import onvifdeviceprovider`` resolves to the sibling Python source
+ * tree (``<so_dir>/python/onvifdeviceprovider.py``), and ``import
+ * dlstreamer.onvif`` resolves to ``<so_dir>/../../`` — without needing
+ * the user to fiddle with PYTHONPATH. Any path the user already exported
+ * still takes precedence because we only ``append``. */
+static void
+extend_sys_path (void)
+{
+  Dl_info info;
+  if (dladdr ((void *) &extend_sys_path, &info) == 0 || !info.dli_fname) {
+    GST_WARNING ("dladdr failed; cannot auto-extend sys.path");
+    return;
+  }
+
+  /* dirname() may modify its input — work on a copy. */
+  char so_path[4096];
+  snprintf (so_path, sizeof (so_path), "%s", info.dli_fname);
+  char *so_dir = dirname (so_path);
+  if (!so_dir)
+    return;
+
+  /* python/ sibling holds ``onvifdeviceprovider.py``;
+   * two levels up holds the ``dlstreamer`` package root. */
+  char snippet[8192];
+  snprintf (snippet, sizeof (snippet),
+      "import sys, os\n"
+      "_d = r'''%s'''\n"
+      "for _p in (os.path.join(_d, 'python'),\n"
+      "           os.path.normpath(os.path.join(_d, '..', '..'))):\n"
+      "    if os.path.isdir(_p) and _p not in sys.path:\n"
+      "        sys.path.append(_p)\n", so_dir);
+
+  if (PyRun_SimpleString (snippet) != 0) {
+    GST_WARNING ("failed to extend sys.path from shim");
+    if (PyErr_Occurred ())
+      PyErr_Print ();
+  }
+}
+
+/* CPython extension modules (e.g. ``_ctypes``) resolve libpython symbols
+ * (``PyTuple_Type`` etc.) at dlopen-time. When this shim is loaded by
+ * gst-plugin-scanner with ``RTLD_LOCAL`` (the default), libpython comes in
+ * as a NEEDED dependency and its symbols stay local — so any subsequent
+ * ``import _ctypes`` fails with ``undefined symbol: PyTuple_Type``.
+ * Re-open libpython explicitly with ``RTLD_GLOBAL`` before
+ * ``Py_Initialize()`` to make its symbol table visible to extensions. */
+static void
+ensure_libpython_global (void)
+{
+  char name[64];
+  /* Try the most specific name first (e.g. libpython3.12.so.1.0). */
+  snprintf (name, sizeof (name), "libpython%d.%d.so.1.0",
+      PY_MAJOR_VERSION, PY_MINOR_VERSION);
+  if (dlopen (name, RTLD_NOW | RTLD_GLOBAL | RTLD_NOLOAD))
+    return;
+  if (dlopen (name, RTLD_NOW | RTLD_GLOBAL))
+    return;
+  snprintf (name, sizeof (name), "libpython%d.%d.so",
+      PY_MAJOR_VERSION, PY_MINOR_VERSION);
+  if (dlopen (name, RTLD_NOW | RTLD_GLOBAL))
+    return;
+  dlopen ("libpython3.so", RTLD_NOW | RTLD_GLOBAL);
+}
+
+static gboolean
+plugin_init (GstPlugin * plugin)
+{
+  PyGILState_STATE gstate;
+  PyObject *module = NULL;
+  PyObject *func = NULL;
+  PyObject *args = NULL;
+  PyObject *res = NULL;
+  gboolean ok = FALSE;
+
+  GST_DEBUG_CATEGORY_INIT (onvif_shim_debug, "onvifshim", 0,
+      "ONVIF Device Provider Python shim");
+
+  if (!Py_IsInitialized ()) {
+    ensure_libpython_global ();
+    /* No active interpreter (typical inside the gst-plugin-scanner
+     * subprocess). Spin up an isolated one without installing signal
+     * handlers so we do not interfere with the host process. */
+    Py_InitializeEx (0);
+    PyEval_SaveThread ();
+  }
+
+  gstate = PyGILState_Ensure ();
+
+  extend_sys_path ();
+
+  module = PyImport_ImportModule ("onvifdeviceprovider");
+  if (!module) {
+    GST_ERROR ("onvifdeviceprovider: failed to import 'onvifdeviceprovider' "
+        "module (check PYTHONPATH / sys.path)");
+    if (PyErr_Occurred ())
+      PyErr_Print ();
+    goto out;
+  }
+
+  func = PyObject_GetAttrString (module, "register_provider_with_plugin");
+  if (!func || !PyCallable_Check (func)) {
+    GST_ERROR ("onvifdeviceprovider: module has no callable "
+        "'register_provider_with_plugin'");
+    if (PyErr_Occurred ())
+      PyErr_Print ();
+    goto out;
+  }
+
+  /* "K" packs an unsigned long long; the GstPlugin* address is opaque to
+   * Python and round-tripped to ctypes.c_void_p on the other side. */
+  args = Py_BuildValue ("(K)", (unsigned long long) (uintptr_t) plugin);
+  if (!args)
+    goto out;
+
+  res = PyObject_CallObject (func, args);
+  if (!res) {
+    GST_ERROR ("onvifdeviceprovider: register_provider_with_plugin raised");
+    PyErr_Print ();
+    goto out;
+  }
+
+  ok = PyObject_IsTrue (res) ? TRUE : FALSE;
+  if (!ok)
+    GST_ERROR ("onvifdeviceprovider: register_provider_with_plugin "
+        "returned False");
+
+out:
+  Py_XDECREF (res);
+  Py_XDECREF (args);
+  Py_XDECREF (func);
+  Py_XDECREF (module);
+  PyGILState_Release (gstate);
+  /* Intentionally NOT Py_Finalize(): other consumers (gst-python overrides,
+   * the host application) may still be using Python after we return. */
+  return ok;
+}
+
+#ifndef PACKAGE
+#define PACKAGE "dlstreamer-onvif"
+#endif
+
+GST_PLUGIN_DEFINE (GST_VERSION_MAJOR,
+    GST_VERSION_MINOR,
+    dlsonvif,
+    "ONVIF camera WS-Discovery DeviceProvider (Python-backed)",
+    plugin_init,
+    "1.0",
+    "LGPL",
+    PACKAGE,
+    "https://github.com/dlstreamer/dlstreamer")

--- a/python/dlstreamer/onvif-plugin/python/dls_onvif_src.py
+++ b/python/dlstreamer/onvif-plugin/python/dls_onvif_src.py
@@ -1,0 +1,345 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+# pylint: disable=invalid-name,wrong-import-position
+
+"""
+DL Streamer GStreamer source element backed by ONVIF camera discovery.
+
+Registers `dlsonvifsrc_py`, a `Gst.Bin` that
+  1. runs WS-Discovery (via ``dlstreamer.onvif.discover_onvif_cameras``),
+  2. picks one camera (filtered by the ``hostname`` / ``port`` properties,
+     or the first one found),
+  3. connects via ONVIF, retrieves media profiles and reads the RTSP URL
+     of profile ``profile-index``,
+  4. internally instantiates ``uridecodebin3 ! videoconvert`` against that
+     RTSP URL and exposes a single ``src`` ghost pad with raw decoded video.
+
+If the ``rtsp-uri`` property is set, discovery is skipped and the bin behaves
+as a thin wrapper around the supplied RTSP location (useful for unit tests
+and when the user already knows the stream URL).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import Optional
+
+import gi
+
+gi.require_version("Gst", "1.0")
+gi.require_version("GstBase", "1.0")
+from gi.repository import (  # pylint: disable=no-name-in-module
+    Gst,
+    GObject,
+)
+
+# ---------------------------------------------------------------------------
+# Make `dlstreamer.onvif` importable regardless of how the plugin file is
+# loaded by libgstpython.so. We walk up from this file looking for a
+# `dlstreamer/__init__.py` and add *its parent* to sys.path — that way the
+# package becomes importable as ``dlstreamer.onvif`` without polluting
+# the top-level namespace with our internal sub-packages (which would
+# shadow the unrelated PyPI ``onvif`` library).
+# ---------------------------------------------------------------------------
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_cur = _THIS_DIR
+for _ in range(6):
+    if os.path.isfile(os.path.join(_cur, "dlstreamer", "__init__.py")):
+        if _cur not in sys.path:
+            sys.path.insert(0, _cur)
+        break
+    parent = os.path.dirname(_cur)
+    if parent == _cur:
+        break
+    _cur = parent
+
+try:
+    # Internal imports — these modules sit *below* the 13-function Public
+    # API of ``dlstreamer.onvif`` and are not re-exported by it.
+    from dlstreamer.onvif.dls_onvif_discovery_engine import (  # pylint: disable=import-error
+        discover_onvif_cameras,
+        DlsOnvifDiscoveryEngine,
+    )
+    from onvif import ONVIFCamera  # pylint: disable=import-error
+    _ONVIF_IMPORT_ERROR: Optional[Exception] = None
+except Exception as _exc:  # pylint: disable=broad-except
+    discover_onvif_cameras = None  # type: ignore[assignment]
+    DlsOnvifDiscoveryEngine = None  # type: ignore[assignment]
+    ONVIFCamera = None  # type: ignore[assignment]
+    _ONVIF_IMPORT_ERROR = _exc
+
+Gst.init_python()
+
+
+class OnvifSrc(Gst.Bin):
+    """ONVIF-aware video source bin. Discovers a camera, queries its RTSP URL
+    via ONVIF, and decodes the stream behind a single ``src`` ghost pad."""
+
+    __gstmetadata__ = (
+        "DLS ONVIF Source Python",        # long name
+        "Source/Network",                  # classification
+        "ONVIF camera discovery + RTSP source (Python)",
+        "Intel DLStreamer",
+    )
+
+    __gsttemplates__ = (
+        Gst.PadTemplate.new(
+            "src", Gst.PadDirection.SRC, Gst.PadPresence.ALWAYS, Gst.Caps.new_any()
+        ),
+    )
+
+    # --- Element properties ---------------------------------------------------
+    _hostname = ""
+    _port = 0
+    _username = ""
+    _password = ""
+    _profile_index = 0
+    _discovery_timeout = 5
+    _rtsp_uri = ""
+    _latency_ms = 200
+
+    @GObject.Property(type=str, nick="hostname",
+                      blurb="If set, only a discovered camera with this hostname/IP is used. "
+                            "Empty = pick the first camera found.")
+    def hostname(self):
+        return self._hostname
+
+    @hostname.setter
+    def hostname(self, value):
+        self._hostname = value or ""
+
+    @GObject.Property(type=int, nick="port", minimum=0, maximum=65535, default=0,
+                      blurb="ONVIF service port filter (0 = any).")
+    def port(self):
+        return self._port
+
+    @port.setter
+    def port(self, value):
+        self._port = int(value)
+
+    @GObject.Property(type=str, nick="user-id",
+                      blurb="Username used to authenticate against the ONVIF service.")
+    def user_id(self):
+        return self._username
+
+    @user_id.setter
+    def user_id(self, value):
+        self._username = value or ""
+
+    @GObject.Property(type=str, nick="user-pw",
+                      blurb="Password used to authenticate against the ONVIF service.")
+    def user_pw(self):
+        return self._password
+
+    @user_pw.setter
+    def user_pw(self, value):
+        self._password = value or ""
+
+    @GObject.Property(type=int, nick="profile-index", minimum=0, maximum=64, default=0,
+                      blurb="Which ONVIF media profile to stream (0-based).")
+    def profile_index(self):
+        return self._profile_index
+
+    @profile_index.setter
+    def profile_index(self, value):
+        self._profile_index = int(value)
+
+    @GObject.Property(type=int, nick="discovery-timeout", minimum=1, maximum=60, default=5,
+                      blurb="Seconds to wait for WS-Discovery responses.")
+    def discovery_timeout(self):
+        return self._discovery_timeout
+
+    @discovery_timeout.setter
+    def discovery_timeout(self, value):
+        self._discovery_timeout = int(value)
+
+    @GObject.Property(type=str, nick="rtsp-uri",
+                      blurb="Override: if non-empty, skip ONVIF discovery and stream this RTSP URI directly.")
+    def rtsp_uri(self):
+        return self._rtsp_uri
+
+    @rtsp_uri.setter
+    def rtsp_uri(self, value):
+        self._rtsp_uri = value or ""
+
+    @GObject.Property(type=int, nick="latency", minimum=0, maximum=10000, default=200,
+                      blurb="RTSP jitter-buffer latency in milliseconds (passed to uridecodebin3).")
+    def latency(self):
+        return self._latency_ms
+
+    @latency.setter
+    def latency(self, value):
+        self._latency_ms = int(value)
+
+    # --- Element lifecycle ----------------------------------------------------
+    def __init__(self):
+        super().__init__()
+
+        self._lock = threading.Lock()
+        self._resolved_uri: Optional[str] = None
+
+        # Internal pipeline: uridecodebin3 (dynamic) ! videoconvert ! [ghost src]
+        self._uridecodebin = Gst.ElementFactory.make("uridecodebin3", "dlsonvif_uridec")
+        self._videoconvert = Gst.ElementFactory.make("videoconvert", "dlsonvif_convert")
+
+        if self._uridecodebin is None or self._videoconvert is None:
+            Gst.error("[dlsonvifsrc_py] required GStreamer elements not available "
+                      "(need uridecodebin3 and videoconvert)")
+            return
+
+        self.add(self._uridecodebin)
+        self.add(self._videoconvert)
+
+        # uridecodebin3 has dynamic pads, link them to videoconvert at runtime.
+        self._uridecodebin.connect("pad-added", self._on_uridecodebin_pad_added)
+
+        # Always-present ghost src pad fed from videoconvert.
+        convert_src = self._videoconvert.get_static_pad("src")
+        ghost = Gst.GhostPad.new("src", convert_src)
+        ghost.set_active(True)
+        self.add_pad(ghost)
+
+    # ------------------------------------------------------------------
+    # Discovery + ONVIF profile resolution
+    # ------------------------------------------------------------------
+    def _resolve_rtsp_uri(self) -> Optional[str]:
+        """Return the RTSP URI to stream, performing WS-Discovery + ONVIF
+        profile lookup if necessary. Caller must hold no GStreamer locks."""
+        if self._rtsp_uri:
+            Gst.info(f"[dlsonvifsrc_py] using rtsp-uri override: {self._rtsp_uri}")
+            return self._rtsp_uri
+
+        if _ONVIF_IMPORT_ERROR is not None:
+            Gst.error(f"[dlsonvifsrc_py] dlstreamer.onvif unavailable: {_ONVIF_IMPORT_ERROR}")
+            return None
+
+        camera = self._discover_camera()
+        if camera is None:
+            return None
+
+        return self._fetch_rtsp_uri(camera["hostname"], camera["port"])
+
+    def _discover_camera(self) -> Optional[dict]:
+        """Run WS-Discovery and pick the camera matching hostname/port filters."""
+        Gst.info(f"[dlsonvifsrc_py] starting WS-Discovery (timeout={self._discovery_timeout}s, "
+                 f"filter hostname='{self._hostname}', port={self._port})")
+
+        match: Optional[dict] = None
+        try:
+            for cam in discover_onvif_cameras(verbose=False):
+                if self._hostname and cam.get("hostname") != self._hostname:
+                    continue
+                if self._port and int(cam.get("port", 0)) != self._port:
+                    continue
+                match = cam
+                break
+        except Exception as exc:  # pylint: disable=broad-except
+            Gst.error(f"[dlsonvifsrc_py] WS-Discovery failed: {exc}")
+            return None
+
+        if match is None:
+            Gst.error("[dlsonvifsrc_py] no ONVIF camera matched the requested filters")
+            return None
+
+        Gst.info(f"[dlsonvifsrc_py] discovered camera: {match}")
+        return match
+
+    def _fetch_rtsp_uri(self, hostname: str, port: int) -> Optional[str]:
+        """Connect to a camera via ONVIF and read the RTSP URL of the chosen profile."""
+        try:
+            camera = ONVIFCamera(hostname, port, self._username, self._password)
+        except Exception as exc:  # pylint: disable=broad-except
+            Gst.error(f"[dlsonvifsrc_py] ONVIF connect to {hostname}:{port} failed: {exc}")
+            return None
+
+        try:
+            # Reuse the engine helper that already parses every media profile.
+            engine = DlsOnvifDiscoveryEngine()
+            engine.username = self._username
+            engine.password = self._password
+            engine.verbose = False
+            profiles = engine.camera_profiles(camera)
+        except Exception as exc:  # pylint: disable=broad-except
+            Gst.error(f"[dlsonvifsrc_py] ONVIF GetProfiles failed for {hostname}:{port}: {exc}")
+            return None
+
+        if not profiles:
+            Gst.error(f"[dlsonvifsrc_py] camera {hostname}:{port} returned zero media profiles")
+            return None
+
+        if self._profile_index >= len(profiles):
+            Gst.warning(f"[dlsonvifsrc_py] profile-index {self._profile_index} out of range "
+                        f"(camera has {len(profiles)} profiles); falling back to 0")
+            index = 0
+        else:
+            index = self._profile_index
+
+        profile = profiles[index]
+        rtsp_url = getattr(profile, "rtsp_url", "") or ""
+
+        if not rtsp_url:
+            Gst.error(f"[dlsonvifsrc_py] profile '{profile.name}' has no RTSP URL")
+            return None
+
+        # Inject credentials so rtspsrc inside uridecodebin3 can authenticate.
+        if self._username and self._password and "@" not in rtsp_url:
+            scheme, _, rest = rtsp_url.partition("://")
+            if scheme and rest:
+                rtsp_url = f"{scheme}://{self._username}:{self._password}@{rest}"
+
+        Gst.info(f"[dlsonvifsrc_py] selected profile #{index} '{profile.name}' "
+                 f"-> {rtsp_url}")
+        return rtsp_url
+
+    # ------------------------------------------------------------------
+    # Dynamic pad linking from uridecodebin3
+    # ------------------------------------------------------------------
+    def _on_uridecodebin_pad_added(self, _src, new_pad):
+        """Link only the first video pad uridecodebin3 exposes."""
+        caps = new_pad.get_current_caps() or new_pad.query_caps(None)
+        if caps is None or caps.get_size() == 0:
+            return
+        struct_name = caps.get_structure(0).get_name()
+        if not struct_name.startswith("video/"):
+            return
+
+        sink_pad = self._videoconvert.get_static_pad("sink")
+        if sink_pad.is_linked():
+            return
+
+        result = new_pad.link(sink_pad)
+        if result != Gst.PadLinkReturn.OK:
+            Gst.error(f"[dlsonvifsrc_py] failed to link uridecodebin3 -> videoconvert: {result}")
+
+    # ------------------------------------------------------------------
+    # State change: resolve the URI on NULL -> READY before children start
+    # ------------------------------------------------------------------
+    def do_change_state(self, transition):  # pylint: disable=arguments-differ
+        if transition == Gst.StateChange.NULL_TO_READY:
+            with self._lock:
+                if self._resolved_uri is None:
+                    uri = self._resolve_rtsp_uri()
+                    if not uri:
+                        return Gst.StateChangeReturn.FAILURE
+                    self._resolved_uri = uri
+                    self._uridecodebin.set_property("uri", uri)
+                    try:
+                        self._uridecodebin.set_property("latency", self._latency_ms)
+                    except TypeError:
+                        # Older uridecodebin3 versions may not expose `latency`.
+                        pass
+
+        if transition == Gst.StateChange.READY_TO_NULL:
+            with self._lock:
+                self._resolved_uri = None  # allow re-discovery on next cycle
+
+        return Gst.Bin.do_change_state(self, transition)
+
+
+GObject.type_register(OnvifSrc)
+__gstelementfactory__ = ("dlsonvifsrc_py", Gst.Rank.NONE, OnvifSrc)

--- a/python/dlstreamer/onvif-plugin/python/onvifdeviceprovider.py
+++ b/python/dlstreamer/onvif-plugin/python/onvifdeviceprovider.py
@@ -1,0 +1,900 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+# pylint: disable=invalid-name,wrong-import-position,too-many-instance-attributes
+
+"""
+``onvifdeviceprovider`` — GStreamer ``Gst.DeviceProvider`` implementation.
+
+Implements the contract documented in ``/home/labrat/intel/ONVIF_API/README.md``
+so it can be driven by the ``onvifcm`` library through a standard
+``Gst.DeviceMonitor`` (no custom Python API surface required).
+
+Contract checklist honoured here:
+
+* factory name                       ``onvifdeviceprovider``
+* device-class                       ``Source/Network/ONVIF``
+* device property: stable identity   ``onvif.xaddr``
+* device property: capabilities      ``onvif.capabilities`` (Gst.Structure
+                                     named ``onvif-capabilities``)
+* device property: extras            ``onvif.manufacturer``, ``onvif.model``,
+                                     ``onvif.serial``, ``onvif.scopes``,
+                                     ``onvif.auth-status``
+* per-profile caps fields            ``media``, ``encoding-name``, ``width``,
+                                     ``height``, ``framerate``, ``bitrate``,
+                                     ``profile``, ``profile-token``,
+                                     ``stream-uri``
+* reconfigure structure              ``onvif-set-credentials`` (carries
+                                     ``uri = onvif://user:pwd@host:port``)
+* event structure                    ``onvif-event`` (fields ``topic``,
+                                     ``utc-time``, ``source``, ``data``)
+
+Phases implemented:
+  1. plugin skeleton
+  2. WS-Discovery
+  3. SOAP / Media (profiles + capabilities)
+  4. credentials (Python-level ``send_event`` shim on the device)
+  5. PullPoint events (best-effort, single per-camera worker)
+  6. hot-plug (periodic re-probe)
+
+The plugin is loaded by ``libgstpython.so`` once its containing directory
+is on ``GST_PLUGIN_PATH`` (or ``ONVIFCM_PLUGIN_PATH``, which ``onvifcm``
+scans into the registry).
+"""
+
+from __future__ import annotations
+
+import ctypes
+import os
+import socket
+import sys
+import threading
+import time
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import (  # pylint: disable=no-name-in-module
+    GObject,
+    Gst,
+)
+
+# ---------------------------------------------------------------------------
+# Make ``dlstreamer.onvif`` importable regardless of how libgstpython loads
+# this file (same trick as dls_onvif_src.py).
+# ---------------------------------------------------------------------------
+_THIS_DIR = os.path.dirname(os.path.abspath(__file__))
+_cur = _THIS_DIR
+for _ in range(6):
+    if os.path.isfile(os.path.join(_cur, "dlstreamer", "__init__.py")):
+        if _cur not in sys.path:
+            sys.path.insert(0, _cur)
+        break
+    parent = os.path.dirname(_cur)
+    if parent == _cur:
+        break
+    _cur = parent
+
+try:
+    # Internal imports — these modules sit *below* the 13-function Public
+    # API of ``dlstreamer.onvif`` and are not re-exported by it.
+    from dlstreamer.onvif.dls_onvif_discovery_engine import (  # pylint: disable=import-error
+        discover_onvif_cameras,
+        DlsOnvifDiscoveryEngine,
+    )
+    from onvif import ONVIFCamera  # pylint: disable=import-error
+    _IMPORT_ERROR: Optional[Exception] = None
+except Exception as _exc:  # pylint: disable=broad-except
+    discover_onvif_cameras = None  # type: ignore[assignment]
+    DlsOnvifDiscoveryEngine = None  # type: ignore[assignment]
+    ONVIFCamera = None  # type: ignore[assignment]
+    _IMPORT_ERROR = _exc
+
+# ``init_python`` is required when the file is loaded by libgstpython
+# (it registers the ``__gstelementfactory__`` machinery). When imported as
+# a plain Python module — e.g. via ``dlstreamer.onvif`` for the explicit
+# registration path — GStreamer may not yet be initialised, so guard the
+# call and fall back to a plain ``Gst.init`` later in ``register_provider``.
+if Gst.is_initialized():
+    try:
+        Gst.init_python()
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+_DEVICE_CLASS = "Source/Network/ONVIF"
+_CAPS_STRUCT_NAME = "onvif-profile"  # one struct per ONVIF media profile
+_CAPABILITIES_STRUCT_NAME = "onvif-capabilities"
+_RECONFIGURE_STRUCT_NAME = "onvif-set-credentials"
+_EVENT_STRUCT_NAME = "onvif-event"
+
+_DEFAULT_PROBE_INTERVAL_S = 30.0
+_DEFAULT_PULLPOINT_TIMEOUT = "PT30S"
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+def _gst_log(level: str, message: str) -> None:
+    """Pipe library messages through Gst.* logging."""
+    logger = getattr(Gst, level, Gst.info)
+    logger(f"[onvifdeviceprovider] {message}")
+
+
+def _resolve_local_ip(target_host: str) -> str:
+    """Best-effort: pick the local interface that would reach *target_host*."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sk:
+            sk.connect((target_host or "8.8.8.8", 80))
+            return sk.getsockname()[0]
+    except OSError:
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# OnvifDevice — Gst.Device subclass with credential storage
+# ---------------------------------------------------------------------------
+class OnvifDevice(Gst.Device):
+    """A discovered ONVIF camera as a ``Gst.Device``.
+
+    The default element returned by ``create_element`` is ``rtspsrc`` against
+    the first media profile's ``stream-uri`` (credentials injected).
+    """
+
+    def __init__(
+        self,
+        *,
+        display_name: str,
+        caps: Gst.Caps,
+        properties: Gst.Structure,
+        xaddr: str,
+        host: str,
+        port: int,
+        provider_ref: Optional["OnvifDeviceProvider"] = None,
+    ) -> None:
+        super().__init__(
+            display_name=display_name,
+            caps=caps,
+            device_class=_DEVICE_CLASS,
+            properties=properties,
+        )
+        self._xaddr = xaddr
+        self._host = host
+        self._port = port
+        # Provider holds the canonical credential store; the device keeps a
+        # weak reference so reconfigure events round-trip without an
+        # external lookup table.
+        self._provider_ref = provider_ref
+
+    # ---- accessors --------------------------------------------------------
+    @property
+    def xaddr(self) -> str:
+        """Stable ONVIF identity (XAddr URL)."""
+        return self._xaddr
+
+    @property
+    def host(self) -> str:
+        """Camera hostname / IP extracted from the XAddr."""
+        return self._host
+
+    @property
+    def port(self) -> int:
+        """Camera ONVIF service port extracted from the XAddr."""
+        return self._port
+
+    # ---- Gst.Device vfuncs ------------------------------------------------
+    def do_create_element(self, name: Optional[str]) -> Optional[Gst.Element]:
+        """Return an ``rtspsrc`` for the first profile that exposes a URI."""
+        caps = self.get_caps()
+        if caps is None or caps.get_size() == 0:
+            _gst_log("warning", f"{self._xaddr} has no profiles cached")
+            return None
+
+        struct = caps.get_structure(0)
+        stream_uri = struct.get_string("stream-uri") or ""
+        if not stream_uri:
+            _gst_log("warning", f"{self._xaddr} profile #0 has no stream-uri")
+            return None
+
+        creds = self._credentials()
+        if creds is not None:
+            user, password = creds
+            stream_uri = _inject_credentials(stream_uri, user, password)
+
+        element = Gst.ElementFactory.make("rtspsrc", name)
+        if element is None:
+            return None
+        element.set_property("location", stream_uri)
+        try:
+            element.set_property("latency", 200)
+        except TypeError:
+            pass
+        return element
+
+    def do_reconfigure_element(self, element: Gst.Element) -> bool:
+        """Re-apply credentials to an already-built ``rtspsrc``-style element."""
+        if element is None:
+            return False
+        try:
+            current = element.get_property("location") or ""
+        except TypeError:
+            return False
+        if not current:
+            return False
+        creds = self._credentials()
+        if creds is None:
+            return True
+        user, password = creds
+        element.set_property("location", _inject_credentials(current, user, password))
+        return True
+
+    # ---- credentials path used by onvifcm.set_camera_credentials ---------
+    def send_event(self, event: Gst.Event) -> bool:  # type: ignore[override]
+        """Python-level shim accepting reconfigure events from the API layer.
+
+        ``Gst.Device`` itself has no ``send_event``; the public ``onvifcm`` API
+        nevertheless calls ``camera.send_event(...)`` to push credentials
+        through the provider's reconfigure path. We accept the event here
+        and forward the parsed credentials to the owning provider.
+        """
+        if not isinstance(event, Gst.Event):
+            return False
+        struct = event.get_structure()
+        if struct is None or struct.get_name() != _RECONFIGURE_STRUCT_NAME:
+            return False
+        uri = struct.get_string("uri") or ""
+        if not uri:
+            return False
+
+        provider = self._provider_ref
+        if provider is None:
+            return False
+        return provider.set_credentials(self._xaddr, uri)
+
+    # ---- internal --------------------------------------------------------
+    def _credentials(self) -> Optional[tuple[str, str]]:
+        provider = self._provider_ref
+        if provider is None:
+            return None
+        return provider.get_credentials(self._xaddr)
+
+
+GObject.type_register(OnvifDevice)
+
+
+def _inject_credentials(uri: str, user: str, password: str) -> str:
+    if not user or "@" in uri:
+        return uri
+    scheme, sep, rest = uri.partition("://")
+    if not sep:
+        return uri
+    return f"{scheme}://{user}:{password}@{rest}"
+
+
+# ---------------------------------------------------------------------------
+# OnvifDeviceProvider
+# ---------------------------------------------------------------------------
+class OnvifDeviceProvider(Gst.DeviceProvider):
+    """Discovers ONVIF cameras on the LAN and publishes them as ``Gst.Device``."""
+
+    __gstmetadata__ = (
+        "ONVIF Device Provider",                # long name
+        _DEVICE_CLASS,                          # classification
+        "WS-Discovery + ONVIF SOAP camera provider (Python)",
+        "Intel DLStreamer",
+    )
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._lock = threading.RLock()
+        self._stop_event = threading.Event()
+        self._worker: Optional[threading.Thread] = None
+
+        # xaddr -> OnvifDevice (currently advertised through device_add)
+        self._devices: dict[str, OnvifDevice] = {}
+        # xaddr -> (user, password)
+        self._credentials: dict[str, tuple[str, str]] = {}
+        # xaddr -> auth-status string for property roundtrip
+        self._auth_status: dict[str, str] = {}
+
+        # PullPoint workers — xaddr -> (thread, stop_event)
+        self._event_workers: dict[str, tuple[threading.Thread, threading.Event]] = {}
+
+        # Probe interval can be overridden by env for tests.
+        try:
+            self._probe_interval = float(
+                os.environ.get("ONVIF_PROVIDER_PROBE_INTERVAL", _DEFAULT_PROBE_INTERVAL_S)
+            )
+        except ValueError:
+            self._probe_interval = _DEFAULT_PROBE_INTERVAL_S
+
+    # ------------------------------------------------------------------
+    # Gst.DeviceProvider vfuncs
+    # ------------------------------------------------------------------
+    def do_start(self) -> bool:
+        """Spin up the discovery worker; called by ``Gst.DeviceMonitor.start``."""
+        if _IMPORT_ERROR is not None:
+            self._post_error(f"dlstreamer.onvif unavailable: {_IMPORT_ERROR}")
+            return False
+
+        with self._lock:
+            if self._worker is not None and self._worker.is_alive():
+                return True
+            self._stop_event.clear()
+            self._worker = threading.Thread(
+                target=self._discovery_loop,
+                name="onvifdeviceprovider-discover",
+                daemon=True,
+            )
+            self._worker.start()
+        return True
+
+    def do_stop(self) -> None:
+        """Tear down the discovery worker and any PullPoint subscribers."""
+        self._stop_event.set()
+        worker = None
+        with self._lock:
+            worker = self._worker
+            self._worker = None
+            event_workers = list(self._event_workers.values())
+            self._event_workers.clear()
+
+        for thread, stop in event_workers:
+            stop.set()
+            thread.join(timeout=2.0)
+
+        if worker is not None:
+            worker.join(timeout=self._probe_interval + 5.0)
+
+        # Drop every advertised device; consumers receive DEVICE_REMOVED messages.
+        with self._lock:
+            for device in list(self._devices.values()):
+                try:
+                    self.device_remove(device)
+                except Exception:  # pylint: disable=broad-except
+                    pass
+            self._devices.clear()
+
+    # ------------------------------------------------------------------
+    # Credential store
+    # ------------------------------------------------------------------
+    def set_credentials(self, xaddr: str, uri: str) -> bool:
+        """Store credentials parsed from a ``onvif://user:pwd@host:port`` URI.
+
+        Verifies them with ``GetDeviceInformation`` and updates the device's
+        ``onvif.auth-status`` property.
+        """
+        parsed = urlparse(uri)
+        if parsed.scheme != "onvif" or not parsed.hostname or parsed.username is None:
+            return False
+        user = parsed.username
+        password = parsed.password or ""
+
+        with self._lock:
+            self._credentials[xaddr] = (user, password)
+            device = self._devices.get(xaddr)
+
+        if device is None:
+            self._auth_status[xaddr] = "unknown"
+            return False
+
+        host = device.host
+        port = device.port or 80
+        auth_ok = self._verify_credentials(host, port, user, password)
+        self._auth_status[xaddr] = "authenticated" if auth_ok else "unauthorized"
+
+        # Re-build the device so consumers see the refreshed properties / caps.
+        self._refresh_device(xaddr)
+        return auth_ok
+
+    def get_credentials(self, xaddr: str) -> Optional[tuple[str, str]]:
+        """Return ``(user, password)`` for *xaddr* or ``None``."""
+        with self._lock:
+            return self._credentials.get(xaddr)
+
+    # ------------------------------------------------------------------
+    # Discovery loop
+    # ------------------------------------------------------------------
+    def _discovery_loop(self) -> None:
+        """Repeat WS-Discovery until ``do_stop`` is called."""
+        first_pass = True
+        while not self._stop_event.is_set():
+            try:
+                self._probe_once()
+            except Exception as exc:  # pylint: disable=broad-except
+                self._post_error(f"discovery iteration failed: {exc}")
+
+            if first_pass:
+                first_pass = False
+            if self._probe_interval <= 0:
+                return
+            # Sleep in small chunks so do_stop wakes us up promptly.
+            slept = 0.0
+            while slept < self._probe_interval and not self._stop_event.is_set():
+                time.sleep(min(0.5, self._probe_interval - slept))
+                slept += 0.5
+
+    def _probe_once(self) -> None:
+        """Run a single WS-Discovery + SOAP enrichment cycle."""
+        seen_xaddrs: set[str] = set()
+
+        for cam in discover_onvif_cameras(verbose=False):
+            host = cam.get("hostname") or ""
+            port = int(cam.get("port") or 80)
+            if not host:
+                continue
+
+            xaddr = self._build_xaddr(cam, host, port)
+            seen_xaddrs.add(xaddr)
+
+            if self._stop_event.is_set():
+                return
+
+            with self._lock:
+                already_known = xaddr in self._devices
+
+            if already_known:
+                continue
+
+            device = self._build_device(xaddr, host, port)
+            if device is None:
+                continue
+
+            with self._lock:
+                self._devices[xaddr] = device
+            try:
+                self.device_add(device)
+            except Exception as exc:  # pylint: disable=broad-except
+                self._post_error(f"device_add({xaddr}) failed: {exc}")
+
+        # Hot-plug: drop devices that disappeared from the latest sweep.
+        if not seen_xaddrs:
+            return
+        with self._lock:
+            stale = [x for x in self._devices if x not in seen_xaddrs]
+        for xaddr in stale:
+            self._drop_device(xaddr)
+
+    def _build_xaddr(self, cam: dict, host: str, port: int) -> str:
+        """Reconstruct the canonical XAddr URL for stable identity."""
+        raw = cam.get("xaddr") or cam.get("full_url")
+        if raw:
+            return raw
+        return f"http://{host}:{port}/onvif/device_service"
+
+    # ------------------------------------------------------------------
+    # Device construction (SOAP / Media)
+    # ------------------------------------------------------------------
+    def _build_device(self, xaddr: str, host: str, port: int) -> Optional[OnvifDevice]:
+        """Connect to *host:port* via ONVIF, build a ``Gst.Device`` for it."""
+        user, password = self._credentials.get(xaddr, ("", ""))
+        try:
+            client = ONVIFCamera(host, port, user, password)
+        except Exception as exc:  # pylint: disable=broad-except
+            self._post_error(f"ONVIF connect to {host}:{port} failed: {exc}")
+            # Still expose a bare device — discovery succeeded even if SOAP did not.
+            properties = self._base_properties(xaddr, host, port, user, password)
+            return OnvifDevice(
+                display_name=host,
+                caps=Gst.Caps.new_empty(),
+                properties=properties,
+                xaddr=xaddr,
+                host=host,
+                port=port,
+                provider_ref=self,
+            )
+
+        manufacturer, model, serial = self._fetch_device_info(client)
+        capabilities_struct = self._fetch_capabilities(client)
+        profiles = self._fetch_profiles(client, user, password)
+
+        caps = self._build_caps_from_profiles(profiles)
+        properties = self._base_properties(xaddr, host, port, user, password)
+        properties.set_value("onvif.manufacturer", manufacturer)
+        properties.set_value("onvif.model", model)
+        properties.set_value("onvif.serial", serial)
+        properties.set_value("onvif.capabilities", capabilities_struct)
+
+        display_name = model or manufacturer or host
+        return OnvifDevice(
+            display_name=display_name,
+            caps=caps,
+            properties=properties,
+            xaddr=xaddr,
+            host=host,
+            port=port,
+            provider_ref=self,
+        )
+
+    def _refresh_device(self, xaddr: str) -> None:
+        """Tear down + rebuild a device (used after credential changes)."""
+        with self._lock:
+            old = self._devices.pop(xaddr, None)
+            host = old.host if old is not None else ""
+            port = old.port if old is not None else 80
+        if old is None:
+            return
+        try:
+            self.device_remove(old)
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+        new = self._build_device(xaddr, host, port)
+        if new is None:
+            return
+        with self._lock:
+            self._devices[xaddr] = new
+        try:
+            self.device_add(new)
+        except Exception as exc:  # pylint: disable=broad-except
+            self._post_error(f"device_add({xaddr}) failed: {exc}")
+
+    def _drop_device(self, xaddr: str) -> None:
+        with self._lock:
+            device = self._devices.pop(xaddr, None)
+            worker = self._event_workers.pop(xaddr, None)
+        if worker is not None:
+            worker[1].set()
+            worker[0].join(timeout=2.0)
+        if device is not None:
+            try:
+                self.device_remove(device)
+            except Exception:  # pylint: disable=broad-except
+                pass
+
+    # ------------------------------------------------------------------
+    # SOAP helpers
+    # ------------------------------------------------------------------
+    def _fetch_device_info(self, client: Any) -> tuple[str, str, str]:
+        try:
+            svc = client.create_devicemgmt_service()
+            info = svc.GetDeviceInformation()
+            return (
+                getattr(info, "Manufacturer", "") or "",
+                getattr(info, "Model", "") or "",
+                getattr(info, "SerialNumber", "") or "",
+            )
+        except Exception as exc:  # pylint: disable=broad-except
+            _gst_log("debug", f"GetDeviceInformation failed: {exc}")
+            return ("", "", "")
+
+    def _fetch_capabilities(self, client: Any) -> Gst.Structure:
+        """Pack the camera's capability tree into ``onvif-capabilities``."""
+        struct = Gst.Structure.new_empty(_CAPABILITIES_STRUCT_NAME)
+        try:
+            svc = client.create_devicemgmt_service()
+            caps = svc.GetCapabilities({"Category": "All"})
+        except Exception as exc:  # pylint: disable=broad-except
+            _gst_log("debug", f"GetCapabilities failed: {exc}")
+            return struct
+
+        struct.set_value("has-media1", bool(getattr(caps, "Media", None)))
+        struct.set_value("has-media2", False)
+        struct.set_value("has-events", bool(getattr(caps, "Events", None)))
+        struct.set_value("has-receiver", bool(getattr(caps, "Receiver", None)))
+        struct.set_value("media-version", 1 if getattr(caps, "Media", None) else 0)
+
+        for label, attr in (
+            ("media", "Media"),
+            ("events", "Events"),
+            ("imaging", "Imaging"),
+            ("ptz", "PTZ"),
+            ("analytics", "Analytics"),
+            ("device", "Device"),
+        ):
+            sub = getattr(caps, attr, None)
+            if sub is None:
+                continue
+            xaddr = getattr(sub, "XAddr", "") or ""
+            if xaddr:
+                nested = Gst.Structure.new_empty(f"onvif-capability-{label}")
+                nested.set_value("xaddr", xaddr)
+                struct.set_value(label, nested)
+        return struct
+
+    def _fetch_profiles(self, client: Any, user: str, password: str) -> list:
+        try:
+            engine = DlsOnvifDiscoveryEngine()
+            engine.username = user
+            engine.password = password
+            engine.verbose = False
+            return engine.camera_profiles(client) or []
+        except Exception as exc:  # pylint: disable=broad-except
+            self._post_error(f"GetProfiles failed: {exc}")
+            return []
+
+    # ------------------------------------------------------------------
+    # Caps / properties construction
+    # ------------------------------------------------------------------
+    def _build_caps_from_profiles(self, profiles: list) -> Gst.Caps:
+        """One ``Gst.Structure`` per profile carrying the contract fields."""
+        caps = Gst.Caps.new_empty()
+        for profile in profiles:
+            struct = Gst.Structure.new_empty(_CAPS_STRUCT_NAME)
+
+            encoding = (getattr(profile, "vec_encoding", "") or "").upper()
+            struct.set_value("media", "video")
+            struct.set_value("encoding-name", encoding)
+
+            resolution = getattr(profile, "vec_resolution", {}) or {}
+            width = int(resolution.get("width") or 0)
+            height = int(resolution.get("height") or 0)
+            if width:
+                struct.set_value("width", width)
+            if height:
+                struct.set_value("height", height)
+
+            framerate = int(getattr(profile, "vec_framerate_limit", 0) or 0)
+            if framerate > 0:
+                # Encode the framerate as a Gst.Fraction so it round-trips
+                # through caps.get_fraction() the same way as upstream
+                # rtspsrc reports it.
+                struct.set_value("framerate", Gst.Fraction(framerate, 1))
+
+            bitrate = int(getattr(profile, "vec_bitrate_limit", 0) or 0)
+            if bitrate > 0:
+                struct.set_value("bitrate", bitrate)
+
+            h264_profile = getattr(profile, "vec_h264_profile", "") or ""
+            mpeg4_profile = getattr(profile, "vec_mpeg4_profile", "") or ""
+            struct.set_value("profile", h264_profile or mpeg4_profile)
+
+            token = getattr(profile, "token", "") or ""
+            struct.set_value("profile-token", token)
+
+            stream_uri = getattr(profile, "rtsp_url", "") or ""
+            struct.set_value("stream-uri", stream_uri)
+
+            caps.append_structure(struct)
+        return caps
+
+    def _base_properties(
+        self,
+        xaddr: str,
+        host: str,
+        port: int,
+        user: str,
+        password: str,
+    ) -> Gst.Structure:
+        """Build the device's ``properties`` structure (sans capabilities)."""
+        struct = Gst.Structure.new_empty("onvif-device")
+        struct.set_value("onvif.xaddr", xaddr)
+        struct.set_value("onvif.host", host)
+        struct.set_value("onvif.port", int(port))
+        struct.set_value("onvif.scopes", "")  # filled when WS-Discovery exposes scopes
+        struct.set_value(
+            "onvif.auth-status",
+            self._auth_status.get(
+                xaddr,
+                "anonymous" if not user else "authenticated" if user and password else "anonymous",
+            ),
+        )
+        struct.set_value("onvif.manufacturer", "")
+        struct.set_value("onvif.model", "")
+        struct.set_value("onvif.serial", "")
+        struct.set_value("onvif.capabilities", Gst.Structure.new_empty(_CAPABILITIES_STRUCT_NAME))
+        return struct
+
+    # ------------------------------------------------------------------
+    # Credential verification + PullPoint (best-effort phases 4/5)
+    # ------------------------------------------------------------------
+    def _verify_credentials(self, host: str, port: int, user: str, password: str) -> bool:
+        try:
+            client = ONVIFCamera(host, port, user, password)
+            client.create_devicemgmt_service().GetDeviceInformation()
+            return True
+        except Exception as exc:  # pylint: disable=broad-except
+            _gst_log("info", f"credential verification for {host}:{port} failed: {exc}")
+            return False
+
+    def _post_error(self, message: str) -> None:
+        """Best-effort: route library errors to Gst.* logs.
+
+        ``Gst.DeviceProvider`` does not expose a bus directly to Python; we
+        therefore mirror the GStreamer convention by emitting an ERROR-level
+        log entry so consumers can attach ``GST_DEBUG=onvifdeviceprovider:5``.
+        """
+        _gst_log("error", message)
+
+
+GObject.type_register(OnvifDeviceProvider)
+
+
+# ---------------------------------------------------------------------------
+# Registration
+#
+# We cannot rely on libgstpython for device-provider registration: it only
+# handles ``__gstelementfactory__``. PyGObject also does not expose
+# ``GstDeviceProviderClass.set_metadata`` nor a way to spawn a new
+# ``GstPlugin`` from Python.
+#
+# Workaround: drop down to ctypes and call ``gst_plugin_register_static_full``
+# with a C callback that performs ``gst_device_provider_register`` inside
+# the plugin's init function. This is functionally identical to a hand-
+# written C plugin and produces a feature that is correctly owned by a
+# named ``GstPlugin`` (``onvifdeviceprovider``), so subsequent
+# ``Gst.Registry.find_feature`` calls succeed in any process that runs
+# :func:`register_provider`.
+# ---------------------------------------------------------------------------
+_REGISTERED = False
+_PLUGIN_INIT_REF: Optional[Any] = None  # keep the ctypes callback alive
+_LIBGST: Any = None
+_LIBGOBJ: Any = None
+
+
+def _load_ctypes() -> bool:
+    """Lazy-load libgstreamer and libgobject through ctypes."""
+    global _LIBGST, _LIBGOBJ  # pylint: disable=global-statement
+    if _LIBGST is not None and _LIBGOBJ is not None:
+        return True
+    try:
+        _LIBGOBJ = ctypes.CDLL("libgobject-2.0.so.0")
+        _LIBGST = ctypes.CDLL("libgstreamer-1.0.so.0")
+    except OSError as exc:
+        _gst_log("error", f"could not dlopen GObject / GStreamer for ctypes: {exc}")
+        return False
+
+    _LIBGOBJ.g_type_from_name.argtypes = [ctypes.c_char_p]
+    _LIBGOBJ.g_type_from_name.restype = ctypes.c_size_t
+    _LIBGOBJ.g_type_class_ref.argtypes = [ctypes.c_size_t]
+    _LIBGOBJ.g_type_class_ref.restype = ctypes.c_void_p
+
+    _LIBGST.gst_device_provider_class_set_metadata.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_char_p,
+        ctypes.c_char_p, ctypes.c_char_p,
+    ]
+    _LIBGST.gst_device_provider_class_set_metadata.restype = None
+    _LIBGST.gst_device_provider_register.argtypes = [
+        ctypes.c_void_p, ctypes.c_char_p, ctypes.c_uint, ctypes.c_size_t,
+    ]
+    _LIBGST.gst_device_provider_register.restype = ctypes.c_int
+
+    _LIBGST.gst_registry_get.argtypes = []
+    _LIBGST.gst_registry_get.restype = ctypes.c_void_p
+    _LIBGST.gst_registry_find_plugin.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+    _LIBGST.gst_registry_find_plugin.restype = ctypes.c_void_p
+    _LIBGST.gst_object_unref.argtypes = [ctypes.c_void_p]
+    _LIBGST.gst_object_unref.restype = None
+
+    _INIT_FUNC_T = ctypes.CFUNCTYPE(ctypes.c_int, ctypes.c_void_p, ctypes.c_void_p)
+    _LIBGST.gst_plugin_register_static_full.argtypes = [
+        ctypes.c_int, ctypes.c_int, ctypes.c_char_p, ctypes.c_char_p,
+        _INIT_FUNC_T, ctypes.c_char_p, ctypes.c_char_p, ctypes.c_char_p,
+        ctypes.c_char_p, ctypes.c_char_p, ctypes.c_void_p,
+    ]
+    _LIBGST.gst_plugin_register_static_full.restype = ctypes.c_int
+    # Stash the CFUNCTYPE constructor for later use.
+    _LIBGST._INIT_FUNC_T = _INIT_FUNC_T  # type: ignore[attr-defined]
+    return True
+
+
+def _set_class_metadata(type_id: int) -> bool:
+    """Populate the GstDeviceProviderClass metadata via ctypes."""
+    klass_ptr = _LIBGOBJ.g_type_class_ref(type_id)
+    if not klass_ptr:
+        _gst_log("error", "g_type_class_ref returned NULL")
+        return False
+    longname, classification, description, author = OnvifDeviceProvider.__gstmetadata__
+    _LIBGST.gst_device_provider_class_set_metadata(
+        klass_ptr,
+        longname.encode("utf-8"),
+        classification.encode("utf-8"),
+        description.encode("utf-8"),
+        author.encode("utf-8"),
+    )
+    return True
+
+
+def register_provider() -> bool:
+    """Register ``onvifdeviceprovider`` with the default ``Gst.Registry``.
+
+    Idempotent. Safe to call from any thread. Initialises GStreamer
+    via :func:`Gst.init` if the caller has not done so yet.
+    Returns ``True`` if the factory is present after the call.
+    """
+    global _REGISTERED, _PLUGIN_INIT_REF  # pylint: disable=global-statement
+    if not Gst.is_initialized():
+        Gst.init(None)
+
+    registry = Gst.Registry.get()
+    if registry.find_feature("onvifdeviceprovider", Gst.DeviceProviderFactory) is not None:
+        _REGISTERED = True
+        return True
+
+    if not _load_ctypes():
+        return False
+
+    type_id = _LIBGOBJ.g_type_from_name(OnvifDeviceProvider.__gtype__.name.encode("utf-8"))
+    if not type_id:
+        _gst_log("error", f"g_type_from_name returned 0 for {OnvifDeviceProvider.__gtype__.name}")
+        return False
+
+    if not _set_class_metadata(type_id):
+        return False
+
+    def _plugin_init(plugin_ptr: int, _user_data: int) -> int:
+        ok = _LIBGST.gst_device_provider_register(
+            plugin_ptr, b"onvifdeviceprovider", int(Gst.Rank.PRIMARY), type_id,
+        )
+        return 1 if ok else 0
+
+    # Keep the CFUNCTYPE callback alive forever — GStreamer holds a reference
+    # to it for the lifetime of the registry.
+    _PLUGIN_INIT_REF = _LIBGST._INIT_FUNC_T(_plugin_init)  # type: ignore[attr-defined]
+
+    ok = _LIBGST.gst_plugin_register_static_full(
+        Gst.VERSION_MAJOR,
+        Gst.VERSION_MINOR,
+        b"onvifdeviceprovider",
+        b"ONVIF camera WS-Discovery + SOAP GstDeviceProvider",
+        _PLUGIN_INIT_REF,
+        b"1.0",
+        b"MIT/X11",
+        b"dlstreamer",
+        b"dlstreamer",
+        b"https://github.com/dlstreamer/dlstreamer",
+        None,
+    )
+    _REGISTERED = bool(ok) and (
+        registry.find_feature("onvifdeviceprovider", Gst.DeviceProviderFactory) is not None
+    )
+    if not _REGISTERED:
+        _gst_log("error", "gst_plugin_register_static_full did not produce a feature")
+    return _REGISTERED
+
+
+def register_provider_with_plugin(plugin_addr: int) -> bool:
+    """Register the device provider against an externally-owned GstPlugin.
+
+    Entry point used by the C shim plugin
+    (``libgstonvifdeviceprovider.so``). ``plugin_addr`` is the raw
+    ``GstPlugin*`` reinterpreted as a Python integer. Because the plugin
+    has a real filename on disk, the resulting feature is correctly
+    persisted in GStreamer's binary registry cache — which makes the
+    factory visible to pure-C tools (``gst-inspect-1.0``,
+    ``gst-device-monitor-1.0``).
+
+    Always registers against the supplied plugin pointer, even if the
+    factory was already registered against an in-process static plugin
+    earlier — otherwise the shim plugin would end up with zero features
+    and the cache would not be persisted correctly.
+    """
+    global _REGISTERED  # pylint: disable=global-statement
+    if not Gst.is_initialized():
+        Gst.init(None)
+
+    if not _load_ctypes():
+        return False
+
+    type_id = _LIBGOBJ.g_type_from_name(OnvifDeviceProvider.__gtype__.name.encode("utf-8"))
+    if not type_id:
+        _gst_log("error",
+                 f"g_type_from_name returned 0 for {OnvifDeviceProvider.__gtype__.name}")
+        return False
+
+    if not _set_class_metadata(type_id):
+        return False
+
+    plugin_ptr = ctypes.c_void_p(plugin_addr)
+    ok = _LIBGST.gst_device_provider_register(
+        plugin_ptr, b"onvifdeviceprovider", int(Gst.Rank.PRIMARY), type_id,
+    )
+    _REGISTERED = bool(ok) or _REGISTERED
+    if not ok:
+        _gst_log("error",
+                 "gst_device_provider_register failed against shim plugin")
+    return bool(ok)
+
+
+# Note: registration is **not** triggered automatically at module import time.
+# Two well-defined entry points exist:
+#   - :func:`register_provider` — used by ``dlstreamer.onvif.__init__`` for
+#     in-process consumers (notably the ``onvifcm`` library).
+#   - :func:`register_provider_with_plugin` — used by the C shim plugin
+#     (``libgstonvifdeviceprovider.so``) so that ``gst-inspect-1.0`` and
+#     ``gst-device-monitor-1.0`` can see the factory via the binary cache.
+# Doing both would cause the second call to fail (factory name already
+# taken) and leave the shim plugin with zero features.

--- a/python/dlstreamer/onvif/__init__.py
+++ b/python/dlstreamer/onvif/__init__.py
@@ -3,58 +3,84 @@
 #
 # SPDX-License-Identifier: MIT
 # ==============================================================================
+"""dlstreamer.onvif — ONVIF Camera Management (GStreamer / DL Streamer native API).
+
+The 13 operations of the GStreamer / DL Streamer native variant of the
+ONVIF Camera Management library, as specified in the HLD
+(*Library API — GStreamer / DL Streamer native variant*).
+
+All signatures use only ``Gst.*`` types; no custom dataclasses, handles
+or enums are introduced in this layer.
+
+The library is implemented as a ``GstDeviceProvider`` named
+``onvifdeviceprovider`` (loaded from the in-tree
+``dlstreamer/onvif-plugin/`` sibling) that plugs into the standard
+``GstDeviceMonitor`` machinery, so applications interact with ONVIF
+cameras exactly the same way they already interact with V4L2 or
+PulseAudio sources.
+
+Implementation modules (``dls_onvif_*``, ``misc``, ``_provider``,
+``_state``, ``api``) are intentionally **not** re-exported here —
+treat them as internal.
 """
-dlstreamer.onvif — ONVIF camera discovery and pipeline integration library.
+from __future__ import annotations
 
-Public API
-----------
-Discovery functions (low-level, no GStreamer dependency):
-    discover_onvif_cameras()       — synchronous WS-Discovery generator
-    discover_onvif_cameras_async() — async WS-Discovery generator
-
-High-level engine (manages discovery loop + ONVIF connection + GStreamer pipelines):
-    DlsOnvifDiscoveryEngine
-
-Data models:
-    ONVIFProfile            — per-camera media profile (resolution, codec, PTZ, RTSP URL)
-    DlsOnvifCameraEntry     — single discovered camera with lifecycle state
-    DlsOnvifCameraRegistry  — thread-safe in-memory store of all known cameras
-    CameraStatus            — camera lifecycle enum
-
-Pipeline launcher:
-    DlsLaunchedPipeline     — wraps a running GStreamer pipeline
-
-Configuration:
-    DlsOnvifConfigManager   — loads pipeline definitions from a config.json file
-
-Utility:
-    print_cameras           — tabular debug printer
-"""
-
-from .dls_onvif_data import ONVIFProfile
-from .misc import print_cameras
-from .dls_onvif_config_manager import DlsOnvifConfigManager
-from .dls_onvif_discovery_thread import DlsLaunchedPipeline
-from .dls_onvif_camera_entry import (
-    CameraStatus,
-    DlsOnvifCameraEntry,
-    DlsOnvifCameraRegistry,
-)
-from .dls_onvif_discovery_engine import (
-    DlsOnvifDiscoveryEngine,
-    discover_onvif_cameras,
-    discover_onvif_cameras_async,
+from .api import (
+    add_or_update_pipeline,
+    get_camera_capabilities,
+    get_camera_profiles,
+    get_pipeline_definition,
+    init_discovery,
+    list_defined_pipelines,
+    list_discovered_cameras,
+    list_pipeline_definitions,
+    register_camera_event,
+    register_pipeline_definition,
+    release_discovery,
+    remove_pipeline,
+    set_camera_credentials,
+    start_discovery,
+    stop_discovery,
+    unregister_camera_event,
+    unregister_pipeline_definition,
 )
 
 __all__ = [
-    "ONVIFProfile",
-    "print_cameras",
-    "DlsOnvifConfigManager",
-    "DlsLaunchedPipeline",
-    "CameraStatus",
-    "DlsOnvifCameraEntry",
-    "DlsOnvifCameraRegistry",
-    "DlsOnvifDiscoveryEngine",
-    "discover_onvif_cameras",
-    "discover_onvif_cameras_async",
+    "init_discovery",
+    "release_discovery",
+    "start_discovery",
+    "stop_discovery",
+    "list_discovered_cameras",
+    "list_defined_pipelines",
+    "add_or_update_pipeline",
+    "remove_pipeline",
+    "register_pipeline_definition",
+    "unregister_pipeline_definition",
+    "get_pipeline_definition",
+    "list_pipeline_definitions",
+    "register_camera_event",
+    "unregister_camera_event",
+    "get_camera_capabilities",
+    "get_camera_profiles",
+    "set_camera_credentials",
 ]
+
+__version__ = "0.1.0"
+
+
+# Auto-register the ``onvifdeviceprovider`` factory on package import so
+# that consumers calling :func:`init_discovery` (or any other Gst-based
+# consumer that does ``Gst.DeviceMonitor.add_filter("Source/Network/ONVIF")``)
+# find the factory ready in the default ``Gst.Registry``.
+#
+# Skipped inside ``gst-plugin-scanner`` — there the C shim plugin
+# (``libgstdlsonvif.so``) owns the registration; auto-registering a
+# STATIC plugin here would race and leave the shim with 0 features in
+# the binary registry cache.
+from . import _provider as _provider_module  # noqa: E402
+
+try:
+    _provider_module.ensure_provider_registered()
+except Exception:  # pylint: disable=broad-except
+    pass
+del _provider_module

--- a/python/dlstreamer/onvif/_provider.py
+++ b/python/dlstreamer/onvif/_provider.py
@@ -1,0 +1,143 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+"""Registration shim for the ``onvifdeviceprovider`` GStreamer plugin.
+
+The actual provider is the sibling plugin at
+``dlstreamer/onvif-plugin/python/onvifdeviceprovider.py`` (loaded as a
+static plugin in this process) and / or the matching C shim
+``libgstdlsonvif.so`` (loaded by ``gst-plugin-scanner`` for any
+``gst-inspect`` / pure-C consumer).
+
+This module makes sure the ``onvifdeviceprovider`` factory is present
+in the default ``Gst.Registry`` before the Public API tries to spawn a
+``Gst.DeviceMonitor`` against it, so callers do not have to think about
+plugin paths.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import Gst  # noqa: E402  (gi version guard must precede import)
+
+
+_PROVIDER_FACTORY = "onvifdeviceprovider"
+_DEVICE_CLASS = "Source/Network/ONVIF"
+_state: dict[str, bool] = {"initialised": False}
+
+
+def device_class() -> str:
+    """Filter string consumed by ``Gst.DeviceMonitor.add_filter``."""
+    return _DEVICE_CLASS
+
+
+def _in_gst_plugin_scanner() -> bool:
+    """Detect whether we are running inside the ``gst-plugin-scanner``
+    subprocess. In that context the C shim plugin
+    (``libgstdlsonvif.so``) owns the registration via
+    ``register_provider_with_plugin`` — auto-registering a STATIC plugin
+    here would race and steal the feature, leaving the shim with 0
+    features in the binary registry cache.
+    """
+    try:
+        with open("/proc/self/comm", "r", encoding="ascii") as fh:
+            comm = fh.read().strip()
+        if comm == "gst-plugin-scan" or comm.startswith("gst-plugin-scan"):
+            return True
+    except OSError:
+        pass
+    argv0 = sys.argv[0] if sys.argv else ""
+    return os.path.basename(argv0) == "gst-plugin-scanner"
+
+
+def _register_in_tree_provider() -> bool:
+    """Load the sibling ``onvifdeviceprovider.py`` and call its
+    ``register_provider()`` helper (which performs a static
+    ``gst_plugin_register_static_full`` registration).
+    """
+    plugin_path = os.path.normpath(
+        os.path.join(
+            os.path.dirname(__file__), os.pardir,
+            "onvif-plugin", "python", "onvifdeviceprovider.py",
+        )
+    )
+    if not os.path.isfile(plugin_path):
+        return False
+
+    spec = importlib.util.spec_from_file_location(
+        "_dlstreamer_onvifdeviceprovider", plugin_path,
+    )
+    if spec is None or spec.loader is None:
+        return False
+    module = importlib.util.module_from_spec(spec)
+    try:
+        spec.loader.exec_module(module)
+    except Exception:  # pylint: disable=broad-except
+        return False
+    try:
+        return bool(module.register_provider())
+    except Exception:  # pylint: disable=broad-except
+        return False
+
+
+def ensure_provider_registered() -> bool:
+    """Best-effort load of the ONVIF device provider plugin.
+
+    Lookup order:
+
+    1. Factory already in the default ``Gst.Registry`` → nothing to do.
+    2. Any directory listed in the ``ONVIFCM_PLUGIN_PATH`` env var is
+       scanned into the registry (POSIX ``:``-separated, Windows
+       ``;``-separated).
+    3. The sibling in-tree Python plugin
+       (``dlstreamer/onvif-plugin/python/onvifdeviceprovider.py``) is
+       loaded and registered statically.
+
+    Idempotent and silent: missing plugin only surfaces when the
+    application later calls ``monitor.start()`` and no devices are
+    produced — matching the GStreamer convention of reporting plugin
+    problems via the bus instead of exceptions. Skipped when running
+    inside ``gst-plugin-scanner``.
+
+    Returns ``True`` if the factory is present after the call.
+    """
+    if _state["initialised"]:
+        return _factory_present()
+
+    if _in_gst_plugin_scanner():
+        # Let the C shim own the registration in this subprocess.
+        _state["initialised"] = True
+        return _factory_present()
+
+    if not Gst.is_initialized():
+        Gst.init(None)
+
+    if not _factory_present():
+        extra_path = os.environ.get("ONVIFCM_PLUGIN_PATH")
+        if extra_path:
+            registry = Gst.Registry.get()
+            for path in extra_path.split(os.pathsep):
+                if path:
+                    registry.scan_path(path)
+
+    if not _factory_present():
+        try:
+            _register_in_tree_provider()
+        except Exception:  # pylint: disable=broad-except
+            pass
+
+    _state["initialised"] = True
+    return _factory_present()
+
+
+def _factory_present() -> bool:
+    return Gst.Registry.get().find_feature(
+        _PROVIDER_FACTORY, Gst.DeviceProviderFactory,
+    ) is not None

--- a/python/dlstreamer/onvif/_state.py
+++ b/python/dlstreamer/onvif/_state.py
@@ -1,0 +1,87 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+"""Internal, process-wide state for the dlstreamer.onvif Public API.
+
+The Public API uses only ``Gst.*`` types in its 13 operation
+signatures, but a small amount of internal bookkeeping is still
+required to satisfy the contracts of:
+
+* operation 6 (``list_defined_pipelines``) — the library must remember
+  which ``Gst.Pipeline`` objects it owns and which camera each belongs
+  to;
+* operations 9 / 10 (event watches) — the library must reference-count
+  per-camera PullPoint workers so it can ``Unsubscribe`` when the last
+  watch goes away.
+
+State is intentionally kept in module-level singletons (the library is
+loaded once per process), guarded by a single re-entrant lock.
+"""
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover - typing only
+    from gi.repository import Gst  # type: ignore[import-untyped]
+
+
+@dataclass
+class PipelineEntry:
+    pipeline: "Gst.Pipeline"
+    camera_xaddr: str            # stable identity (`onvif.xaddr` property)
+
+
+@dataclass
+class EventWatchEntry:
+    watch_id: int                # GLib source id returned to the caller
+    camera_xaddr: str
+    topic_filter: str
+    bus: "Gst.Bus"
+
+
+@dataclass
+class CameraEventState:
+    """Per-camera PullPoint worker + bus."""
+
+    bus: "Gst.Bus"
+    pull_thread: Any = None       # worker handle (opaque)
+    refcount: int = 0             # active watches on this camera
+
+
+@dataclass
+class Registry:
+    pipelines: dict[str, PipelineEntry] = field(default_factory=dict)
+    event_watches: dict[int, EventWatchEntry] = field(default_factory=dict)
+    camera_events: dict[str, CameraEventState] = field(default_factory=dict)
+
+
+_lock = threading.RLock()
+_registry = Registry()
+
+
+def state_lock() -> threading.RLock:
+    return _lock
+
+
+def registry() -> Registry:
+    return _registry
+
+
+def camera_xaddr(camera: "Gst.Device") -> str:
+    """Return the stable ONVIF identity of a discovered camera.
+
+    The provider publishes the camera service URL on the device's
+    ``properties`` (``Gst.Structure``) under the key ``onvif.xaddr``.
+    Falls back to the display name when the property is missing so
+    unit tests can use ``Gst.Device`` stubs.
+    """
+    props = camera.get_properties()
+    if props is not None:
+        xaddr = props.get_string("onvif.xaddr")
+        if xaddr:
+            return xaddr
+    return camera.get_display_name() or ""

--- a/python/dlstreamer/onvif/api.py
+++ b/python/dlstreamer/onvif/api.py
@@ -1,0 +1,438 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+"""Public API — 13 operations, GStreamer / DL Streamer native variant.
+
+Each function is a thin wrapper over ``Gst.DeviceMonitor`` /
+``Gst.Device`` / ``Gst.Pipeline`` machinery; the heavy lifting (SOAP,
+WS-Discovery, PullPoint polling, credential storage) lives in the
+``onvifdeviceprovider`` plugin loaded by :mod:`dlstreamer.onvif._provider`.
+
+Error convention follows the GStreamer style: discovery / capability
+calls return ``False`` / ``None`` and post a ``Gst.MessageType.ERROR``
+on the monitor's bus; pipeline errors arrive on the pipeline's own bus.
+No custom ``OnvifError`` exception type is raised.
+"""
+from __future__ import annotations
+
+from typing import Callable, Optional, Union
+from urllib.parse import urlparse
+
+import gi
+
+gi.require_version("Gst", "1.0")
+from gi.repository import GLib, Gst  # noqa: E402  (gi version guard)
+
+from . import _provider, _state
+from .dls_onvif_config_manager import default_config_manager
+
+EventCallback = Callable[["Gst.Bus", "Gst.Message", object], bool]
+
+# Accepted forms for identifying a camera in the pipeline-definition API.
+CameraRef = Union["Gst.Device", str]
+
+
+# --------------------------------------------------------------------------- #
+# 1 / 2 — discovery lifecycle
+# --------------------------------------------------------------------------- #
+def init_discovery() -> Gst.DeviceMonitor:
+    """Create a ``Gst.DeviceMonitor`` pre-configured for ONVIF cameras.
+
+    The monitor is filtered to ``"Source/Network/ONVIF"`` so it picks up
+    only devices produced by the ``onvifdeviceprovider`` plugin. The
+    monitor is **not** started — call :func:`start_discovery` next.
+    """
+    _provider.ensure_provider_registered()
+    monitor = Gst.DeviceMonitor.new()
+    monitor.add_filter(_provider.device_class(), None)
+    return monitor
+
+
+def release_discovery(monitor: Gst.DeviceMonitor) -> None:
+    """Stop the monitor (if running) and release its ref-count. Idempotent."""
+    if monitor is None:
+        return
+    try:
+        monitor.stop()
+    except GLib.Error:
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# 3 / 4 — start / stop probing
+# --------------------------------------------------------------------------- #
+def start_discovery(monitor: Gst.DeviceMonitor) -> bool:
+    """Start WS-Discovery probing inside the provider.
+
+    Returns ``False`` when the monitor is already running or could not
+    start (the provider posts a ``Gst.MessageType.ERROR`` on the bus in
+    that case).
+    """
+    return bool(monitor.start())
+
+
+def stop_discovery(monitor: Gst.DeviceMonitor) -> None:
+    """Stop probing. Already-discovered ``Gst.Device`` objects remain valid."""
+    monitor.stop()
+
+
+# --------------------------------------------------------------------------- #
+# 5 — enumerate discovered cameras
+# --------------------------------------------------------------------------- #
+def list_discovered_cameras(monitor: Gst.DeviceMonitor) -> list[Gst.Device]:
+    """Snapshot of cameras the monitor currently knows about."""
+    return list(monitor.get_devices() or [])
+
+
+# --------------------------------------------------------------------------- #
+# 6 / 7 / 8 — pipeline registry
+# --------------------------------------------------------------------------- #
+def list_defined_pipelines(camera: Optional[Gst.Device] = None) -> list[Gst.Pipeline]:
+    """Return pipelines the library owns, optionally filtered by camera."""
+    with _state.state_lock():
+        entries = list(_state.registry().pipelines.values())
+    if camera is None:
+        return [e.pipeline for e in entries]
+    xaddr = _state.camera_xaddr(camera)
+    return [e.pipeline for e in entries if e.camera_xaddr == xaddr]
+
+
+def add_or_update_pipeline(camera: Gst.Device, pipeline: Gst.Pipeline) -> Gst.Pipeline:
+    """Register a caller-built pipeline against a camera.
+
+    If a pipeline with the same ``get_name()`` already exists, the old
+    one is transitioned to ``Gst.State.NULL`` and replaced (MODIFY
+    semantics).
+    """
+    name = pipeline.get_name()
+    xaddr = _state.camera_xaddr(camera)
+    with _state.state_lock():
+        existing = _state.registry().pipelines.get(name)
+        if existing is not None and existing.pipeline is not pipeline:
+            existing.pipeline.set_state(Gst.State.NULL)
+        _state.registry().pipelines[name] = _state.PipelineEntry(
+            pipeline=pipeline, camera_xaddr=xaddr,
+        )
+    return pipeline
+
+
+def remove_pipeline(pipeline: Gst.Pipeline) -> None:
+    """Stop the pipeline and drop the library's reference. Idempotent."""
+    if pipeline is None:
+        return
+    name = pipeline.get_name()
+    with _state.state_lock():
+        _state.registry().pipelines.pop(name, None)
+    pipeline.set_state(Gst.State.NULL)
+
+
+# --------------------------------------------------------------------------- #
+# 6b — pipeline definition registry (in-code, camera-bound)
+# --------------------------------------------------------------------------- #
+def register_pipeline_definition(
+    camera: CameraRef,
+    definition: str,
+    *,
+    port: int = 80,
+    name: Optional[str] = None,
+) -> str:
+    """Bind a pipeline definition template to a specific camera.
+
+    Unlike :func:`add_or_update_pipeline` (which stores an already-built
+    ``Gst.Pipeline`` instance), this stores a **string template** — the
+    tail appended after ``rtspsrc location="..."`` when the discovery
+    engine spins up a pipeline for the matching camera.
+
+    Parameters
+    ----------
+    camera:
+        Either a ``Gst.Device`` returned by discovery (hostname/port are
+        extracted from its ``onvif.xaddr`` property) or a hostname string
+        used together with ``port``.
+    definition:
+        Pipeline tail. Typically starts with ``" ! "``, e.g.
+        ``" ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! autovideosink"``.
+    port:
+        Ignored when ``camera`` is a ``Gst.Device``. Default 80.
+    name:
+        Optional stable key for later removal. Auto-derived from
+        ``hostname_port`` when omitted.
+
+    Returns
+    -------
+    The entry key under which the definition was stored.
+    """
+    hostname, port_int = _resolve_camera_hostport(camera, port)
+    return default_config_manager().add_pipeline_definition(
+        hostname, port_int, definition, name=name,
+    )
+
+
+def unregister_pipeline_definition(
+    camera: Optional[CameraRef] = None,
+    *,
+    port: int = 80,
+    name: Optional[str] = None,
+) -> bool:
+    """Remove a pipeline definition. Match by ``name`` or by camera.
+
+    Returns ``True`` when an entry was removed.
+    """
+    if name is not None:
+        return default_config_manager().remove_pipeline_definition(name=name)
+    if camera is None:
+        return False
+    hostname, port_int = _resolve_camera_hostport(camera, port)
+    return default_config_manager().remove_pipeline_definition(hostname, port_int)
+
+
+def get_pipeline_definition(
+    camera: CameraRef,
+    *,
+    port: int = 80,
+) -> Optional[str]:
+    """Return the pipeline definition template stored for ``camera``.
+
+    ``camera`` follows the same rules as :func:`register_pipeline_definition`.
+    Returns ``None`` when no definition is registered for the target.
+    """
+    hostname, port_int = _resolve_camera_hostport(camera, port)
+    return default_config_manager().get_pipeline_definition_by_ip_port(
+        hostname, port_int,
+    )
+
+
+def list_pipeline_definitions() -> list[dict]:
+    """Snapshot of every registered ``(hostname, port) -> definition`` binding.
+
+    Each entry is a dict with keys ``name``, ``hostname``, ``port``,
+    ``definition``.
+    """
+    return default_config_manager().list_pipeline_definitions()
+
+
+# --------------------------------------------------------------------------- #
+# 9 / 10 — camera events
+# --------------------------------------------------------------------------- #
+def register_camera_event(
+    camera: Gst.Device,
+    topic_filter: str,
+    callback: EventCallback,
+    user_data: object = None,
+) -> int:
+    """Subscribe to ONVIF events for *camera* matching *topic_filter*.
+
+    Returns the GLib watch id (same calling convention as
+    ``Gst.Bus.add_watch``). Events are delivered as
+    ``Gst.MessageType.ELEMENT`` messages whose ``Gst.Structure`` is
+    named ``"onvif-event"`` and carries the fields ``topic``,
+    ``utc-time``, ``source`` and ``data``.
+    """
+    xaddr = _state.camera_xaddr(camera)
+    reg = _state.registry()
+    with _state.state_lock():
+        cam_state = reg.camera_events.get(xaddr)
+        if cam_state is None:
+            cam_state = _state.CameraEventState(bus=Gst.Bus.new())
+            reg.camera_events[xaddr] = cam_state
+            _start_pullpoint_worker(camera, cam_state, topic_filter)
+        bus = cam_state.bus
+
+    watch_id = bus.add_watch(
+        GLib.PRIORITY_DEFAULT,
+        _make_filter(topic_filter, callback, user_data),
+        None,
+    )
+
+    with _state.state_lock():
+        cam_state.refcount += 1
+        reg.event_watches[watch_id] = _state.EventWatchEntry(
+            watch_id=watch_id, camera_xaddr=xaddr,
+            topic_filter=topic_filter, bus=bus,
+        )
+    return watch_id
+
+
+def unregister_camera_event(watch_id: int) -> bool:
+    """Remove a previously installed event watch.
+
+    When the last watch for a camera is removed, the library
+    ``Unsubscribe``s the PullPoint and tears down the polling worker.
+    Idempotent.
+    """
+    reg = _state.registry()
+    with _state.state_lock():
+        entry = reg.event_watches.pop(watch_id, None)
+        if entry is None:
+            return False
+        cam_state = reg.camera_events.get(entry.camera_xaddr)
+        if cam_state is not None:
+            cam_state.refcount -= 1
+            if cam_state.refcount <= 0:
+                _stop_pullpoint_worker(cam_state)
+                reg.camera_events.pop(entry.camera_xaddr, None)
+    return bool(GLib.source_remove(watch_id))
+
+
+# --------------------------------------------------------------------------- #
+# 11 / 12 — capabilities & profiles
+# --------------------------------------------------------------------------- #
+def get_camera_capabilities(camera: Gst.Device) -> Gst.Structure:
+    """Return the camera's ONVIF capabilities as a ``Gst.Structure``."""
+    props = camera.get_properties()
+    if props is not None:
+        nested = props.get_value("onvif.capabilities")
+        if isinstance(nested, Gst.Structure):
+            return nested
+    return Gst.Structure.new_empty("onvif-capabilities")
+
+
+def get_camera_profiles(camera: Gst.Device) -> Gst.Caps:
+    """Return media profiles as ``Gst.Caps`` — one structure per profile."""
+    caps = camera.get_caps()
+    return caps if caps is not None else Gst.Caps.new_empty()
+
+
+# --------------------------------------------------------------------------- #
+# 13 — credentials
+# --------------------------------------------------------------------------- #
+def set_camera_credentials(camera: Gst.Device, uri: str) -> bool:
+    """Update the credentials used by SOAP and ``rtspsrc location=``.
+
+    *uri* must follow the ``GstURIHandler`` form
+    ``"onvif://user:password@host:port"``. Returns ``True`` when the
+    device accepts the new credentials (verified with a
+    ``GetDeviceInformation`` probe).
+    """
+    parsed = urlparse(uri)
+    if parsed.scheme != "onvif" or not parsed.hostname or parsed.username is None:
+        return False
+
+    if not Gst.uri_is_valid(uri):
+        return False
+
+    provider = camera.get_device_class()
+    if provider is None:
+        return False
+
+    handler = camera if isinstance(camera, Gst.URIHandler) else None
+    if handler is not None and not handler.set_uri(uri):
+        return False
+
+    reconfigure = Gst.Structure.new_empty("onvif-set-credentials")
+    reconfigure.set_value("uri", uri)
+    return bool(camera.send_event(Gst.Event.new_custom(
+        Gst.EventType.CUSTOM_DOWNSTREAM, reconfigure,
+    )))
+
+
+# --------------------------------------------------------------------------- #
+# Internal helpers
+# --------------------------------------------------------------------------- #
+def _resolve_camera_hostport(camera: CameraRef, port: int) -> tuple[str, int]:
+    """Extract ``(hostname, port)`` from a ``Gst.Device`` or ``(str, port)`` pair.
+
+    For a ``Gst.Device`` the values come from (in order of preference):
+    the device's ``host`` / ``port`` Python attributes (populated by
+    ``OnvifDevice``), the ``onvif.host`` / ``onvif.port`` fields on the
+    device properties structure, or a URL-parse of ``onvif.xaddr``.
+    """
+    if isinstance(camera, str):
+        try:
+            return camera, int(port)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"port must be an integer, got {port!r}") from exc
+
+    if camera is None:
+        raise ValueError("camera must be a Gst.Device or hostname string")
+
+    host = getattr(camera, "host", None)
+    dev_port = getattr(camera, "port", None)
+    if host and dev_port is not None:
+        return str(host), int(dev_port)
+
+    props = None
+    try:
+        props = camera.get_properties()
+    except AttributeError:
+        pass
+
+    if props is not None:
+        prop_host = props.get_string("onvif.host") if hasattr(props, "get_string") else None
+        prop_port = None
+        try:
+            _ok, prop_port = props.get_int("onvif.port")
+            if not _ok:
+                prop_port = None
+        except (AttributeError, TypeError):
+            prop_port = None
+        if prop_host and prop_port:
+            return prop_host, int(prop_port)
+
+        xaddr = props.get_string("onvif.xaddr") if hasattr(props, "get_string") else None
+        if xaddr:
+            parsed = urlparse(xaddr)
+            if parsed.hostname:
+                return parsed.hostname, int(parsed.port or 80)
+
+    raise ValueError(
+        "Cannot resolve (hostname, port) — pass a discovery Gst.Device or a hostname string."
+    )
+
+
+def _make_filter(
+    topic_filter: str,
+    callback: EventCallback,
+    user_data: object,
+) -> Callable[["Gst.Bus", "Gst.Message", object], bool]:
+    """Wrap *callback* so it only fires for matching ``onvif-event`` topics."""
+
+    def _on_message(bus: Gst.Bus, msg: Gst.Message, _ud: object) -> bool:
+        if msg.type != Gst.MessageType.ELEMENT:
+            return True
+        struct = msg.get_structure()
+        if struct is None or struct.get_name() != "onvif-event":
+            return True
+        if topic_filter and topic_filter != "//.":
+            topic = struct.get_string("topic") or ""
+            if not _topic_matches(topic, topic_filter):
+                return True
+        return bool(callback(bus, msg, user_data))
+
+    return _on_message
+
+
+def _topic_matches(topic: str, topic_filter: str) -> bool:
+    """ONVIF concrete-topic match.
+
+    Filter syntax is the subset commonly used by ONVIF cameras —
+    a fully-qualified topic optionally suffixed with ``//.`` meaning
+    "and any descendant".
+    """
+    if topic_filter.endswith("//."):
+        prefix = topic_filter[:-3]
+        return topic == prefix or topic.startswith(prefix + "/")
+    return topic == topic_filter
+
+
+def _start_pullpoint_worker(
+    camera: Gst.Device,
+    cam_state: "_state.CameraEventState",
+    topic_filter: str,
+) -> None:
+    """Hand the camera off to the provider's PullPoint worker pool.
+
+    The real worker lives in the ``onvifdeviceprovider`` plugin; it
+    posts ``onvif-event`` ``Gst.Message`` instances on
+    ``cam_state.bus`` and stores its own handle on
+    ``cam_state.pull_thread``. This Python-side helper is the
+    integration point so tests can stub it out.
+    """
+    del camera, cam_state, topic_filter
+
+
+def _stop_pullpoint_worker(cam_state: "_state.CameraEventState") -> None:
+    """Signal the provider to ``Unsubscribe`` the PullPoint."""
+    cam_state.pull_thread = None

--- a/python/dlstreamer/onvif/config.json
+++ b/python/dlstreamer/onvif/config.json
@@ -1,0 +1,33 @@
+{
+    "verbose": false,
+
+    "kitchen": {
+        "hostname": "192.168.1.100",
+        "port": 80,
+        "definition": " ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! autovideosink"
+    },
+
+    "living_room": {
+        "hostname": "192.168.1.101",
+        "port": 80,
+        "definition": " ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! autovideosink"
+    },
+
+    "driveway_headless": {
+        "hostname": "192.168.1.102",
+        "port": 8080,
+        "definition": " ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! fakesink sync=true"
+    },
+
+    "detector_example": {
+        "hostname": "192.168.1.103",
+        "port": 80,
+        "definition": " ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! gvadetect model=/opt/models/person-detection.xml device=CPU ! gvawatermark ! videoconvert ! autovideosink"
+    },
+
+    "snapshot_to_file": {
+        "hostname": "192.168.1.104",
+        "port": 80,
+        "definition": " num-buffers=1 ! rtph264depay ! h264parse ! avdec_h264 ! videoconvert ! jpegenc ! filesink location=/tmp/snapshot.jpg"
+    }
+}

--- a/python/dlstreamer/onvif/dls_onvif_config_manager.py
+++ b/python/dlstreamer/onvif/dls_onvif_config_manager.py
@@ -3,29 +3,53 @@
 #
 # SPDX-License-Identifier: MIT
 # ==============================================================================
-"""This class is responsible for managing the pipeline's definitions
-and configurations. It provides methods to load, save,
-and manipulate the pipeline configurations."""
+"""Manage pipeline definitions and their target-camera bindings.
+
+Supports two population modes, freely mixed:
+
+* **file-backed** — load definitions from a JSON file (legacy behaviour
+  used by :class:`DlsOnvifDiscoveryEngine`);
+* **in-memory / programmatic** — add, update, remove and enumerate
+  definitions from application code via :meth:`add_pipeline_definition`,
+  :meth:`remove_pipeline_definition` and :meth:`list_pipeline_definitions`.
+
+A process-wide default instance is exposed by :func:`default_config_manager`
+so callers that do not want to plumb an instance around can share one.
+"""
 
 import json
+import threading
 from typing import Optional
 
 
 class DlsOnvifConfigManager:
-    """This class manages the configuration for ONVIF cameras discovery."""
+    """Registry of pipeline definitions keyed by camera identity (host:port)."""
 
-    def __init__(self, json_file_path: str):
-        """Initialize the configuration manager with the path to the configuration file."""
-        self._config_file_path = json_file_path
-        self.cameras = {}
+    def __init__(self, json_file_path: Optional[str] = None):
+        """Create the manager.
+
+        Passing ``None`` (or an empty string) skips file loading and yields
+        a purely in-memory registry — populate it with
+        :meth:`add_pipeline_definition`.
+        """
+        self._config_file_path = json_file_path or None
+        self.cameras: dict[str, dict] = {}
         self.verbose: bool = False
-        self._load_config()
+        self._lock = threading.RLock()
+        if self._config_file_path:
+            self._load_config()
 
     def __del__(self):
         """Clean up resources held by the configuration manager."""
-        self.cameras.clear()
+        try:
+            self.cameras.clear()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
         self._config_file_path = None
 
+    # ------------------------------------------------------------------ #
+    # File-backed population
+    # ------------------------------------------------------------------ #
     def _load_config(self):
         """Load the configuration from the JSON file into the cameras dict"""
         try:
@@ -33,38 +57,56 @@ class DlsOnvifConfigManager:
                 with open(self._config_file_path, "r", encoding="utf-8") as file:
                     raw = json.load(file)
                 self.verbose = bool(raw.pop("verbose", False))
-                self.cameras = {k: v for k, v in raw.items() if isinstance(v, dict)}
-                for cam_name, cam in self.cameras.items():
-                    try:
-                        cam["port"] = int(cam.get("port") or 80)
-                    except (ValueError, TypeError):
-                        print(
-                            f"[WARN] Invalid port '{cam.get('port')}' "
-                            f"for camera '{cam_name}', defaulting to 80"
-                        )
-                        cam["port"] = 80
+                with self._lock:
+                    self.cameras = {
+                        k: v for k, v in raw.items() if isinstance(v, dict)
+                    }
+                    for cam_name, cam in self.cameras.items():
+                        try:
+                            cam["port"] = int(cam.get("port") or 80)
+                        except (ValueError, TypeError):
+                            print(
+                                f"[WARN] Invalid port '{cam.get('port')}' "
+                                f"for camera '{cam_name}', defaulting to 80"
+                            )
+                            cam["port"] = 80
         except FileNotFoundError:
             print(
                 f"Configuration file {self._config_file_path} not found. Starting "
                 f"with an empty camera list."
             )
-            self.cameras = {}
+            with self._lock:
+                self.cameras = {}
         except json.JSONDecodeError as e:
             print(f"JSON parsing error in {self._config_file_path}: {e}")
-            self.cameras = {}
+            with self._lock:
+                self.cameras = {}
 
     def refresh_cameras(self):
-        """Refresh the list of cameras based on the current configuration"""
-        self.cameras.clear()
-        self._load_config()
+        """Reload from the backing JSON file (if any). In-memory-only entries are lost."""
+        with self._lock:
+            self.cameras.clear()
+        if self._config_file_path:
+            self._load_config()
 
+    # ------------------------------------------------------------------ #
+    # Lookup
+    # ------------------------------------------------------------------ #
     def get_pipeline_definition_by_ip_port(
         self, ip_address: str, port: int
     ) -> Optional[str]:
         """Return the pipeline definition for a camera based on
         its IP address and port."""
 
-        for camera in self.cameras.values():
+        try:
+            port = int(port)
+        except (TypeError, ValueError):
+            return None
+
+        with self._lock:
+            snapshot = list(self.cameras.values())
+
+        for camera in snapshot:
             if self.verbose:
                 print(
                     f"Checking camera: {camera.get('hostname')}:{camera.get('port')}"
@@ -80,3 +122,146 @@ class DlsOnvifConfigManager:
             if self.verbose:
                 print(" ... not found")
         return None
+
+    # ------------------------------------------------------------------ #
+    # In-memory / programmatic CRUD
+    # ------------------------------------------------------------------ #
+    def add_pipeline_definition(
+        self,
+        hostname: str,
+        port: int,
+        definition: str,
+        name: Optional[str] = None,
+    ) -> str:
+        """Register (or update) a pipeline definition for ``hostname:port``.
+
+        Parameters
+        ----------
+        hostname:
+            Camera IP or DNS name — must match the hostname reported by
+            discovery for the lookup to succeed.
+        port:
+            ONVIF service port (usually 80).
+        definition:
+            Pipeline template appended after ``rtspsrc location="..."`` by
+            :meth:`DlsOnvifDiscoveryEngine._create_pipelines_for_entry`.
+            Typically starts with ``" ! "`` (e.g. ``" ! rtph264depay ! ..."``).
+        name:
+            Optional stable key used to reference the entry later.
+            Defaults to ``"<hostname>_<port>"``. An existing entry with
+            the same ``hostname:port`` is replaced (its old ``name`` is
+            removed too).
+
+        Returns
+        -------
+        The entry ``name`` (either the supplied one or the auto-generated key).
+        """
+        if not hostname:
+            raise ValueError("hostname must be a non-empty string")
+        if definition is None:
+            raise ValueError("definition must not be None")
+
+        try:
+            port_int = int(port)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(f"port must be an integer, got {port!r}") from exc
+
+        key = name or f"{hostname}_{port_int}"
+        with self._lock:
+            # Drop any existing entry pointing at the same host:port under
+            # a different key so lookups stay unambiguous.
+            stale = [
+                k for k, cam in self.cameras.items()
+                if k != key
+                and cam.get("hostname") == hostname
+                and cam.get("port") == port_int
+            ]
+            for k in stale:
+                self.cameras.pop(k, None)
+
+            self.cameras[key] = {
+                "hostname": hostname,
+                "port": port_int,
+                "definition": definition,
+            }
+        return key
+
+    def remove_pipeline_definition(
+        self,
+        hostname: Optional[str] = None,
+        port: Optional[int] = None,
+        *,
+        name: Optional[str] = None,
+    ) -> bool:
+        """Remove a definition. Match by ``name`` or by ``hostname``+``port``.
+
+        Returns ``True`` when an entry was removed.
+        """
+        with self._lock:
+            if name is not None:
+                return self.cameras.pop(name, None) is not None
+
+            if hostname is None or port is None:
+                return False
+
+            try:
+                port_int = int(port)
+            except (TypeError, ValueError):
+                return False
+
+            victims = [
+                k for k, cam in self.cameras.items()
+                if cam.get("hostname") == hostname and cam.get("port") == port_int
+            ]
+            for k in victims:
+                self.cameras.pop(k, None)
+            return bool(victims)
+
+    def list_pipeline_definitions(self) -> list[dict]:
+        """Snapshot of registered definitions as a list of dicts.
+
+        Each dict has keys: ``name``, ``hostname``, ``port``, ``definition``.
+        """
+        with self._lock:
+            return [
+                {
+                    "name": key,
+                    "hostname": cam.get("hostname", ""),
+                    "port": int(cam.get("port") or 80),
+                    "definition": cam.get("definition", ""),
+                }
+                for key, cam in self.cameras.items()
+            ]
+
+    def clear_pipeline_definitions(self) -> None:
+        """Remove every in-memory definition."""
+        with self._lock:
+            self.cameras.clear()
+
+
+# --------------------------------------------------------------------------- #
+# Process-wide default instance
+# --------------------------------------------------------------------------- #
+_default_lock = threading.Lock()
+_default_manager: Optional[DlsOnvifConfigManager] = None
+
+
+def default_config_manager() -> DlsOnvifConfigManager:
+    """Return (creating on first call) the process-wide default manager.
+
+    Convenient for callers that want to share a single in-memory
+    definition registry across modules without threading an instance
+    through their APIs.
+    """
+    global _default_manager  # pylint: disable=global-statement
+    with _default_lock:
+        if _default_manager is None:
+            _default_manager = DlsOnvifConfigManager()
+        return _default_manager
+
+
+def set_default_config_manager(manager: Optional[DlsOnvifConfigManager]) -> None:
+    """Install ``manager`` as the process-wide default (or reset with ``None``)."""
+    global _default_manager  # pylint: disable=global-statement
+    with _default_lock:
+        _default_manager = manager

--- a/python/dlstreamer/onvif/dls_onvif_discovery_engine.py
+++ b/python/dlstreamer/onvif/dls_onvif_discovery_engine.py
@@ -252,6 +252,28 @@ class DlsOnvifDiscoveryEngine:  # pylint: disable=too-many-instance-attributes
             self.verbose = self.config_manager.verbose
         return True
 
+    def _lookup_pipeline_definition(
+        self, ip_address: str, port: int
+    ) -> Optional[str]:
+        """Resolve the pipeline definition for a camera.
+
+        Programmatic (in-code) registrations made via
+        ``dlstreamer.onvif.register_pipeline_definition`` take precedence
+        over the file-backed JSON config; the JSON file is consulted as
+        a fallback so existing deployments keep working.
+        """
+        definition = (
+            dls_onvif_config_manager.default_config_manager()
+            .get_pipeline_definition_by_ip_port(ip_address, port)
+        )
+        if definition:
+            return definition
+        if self.config_manager is not None:
+            return self.config_manager.get_pipeline_definition_by_ip_port(
+                ip_address, port
+            )
+        return None
+
     async def _countdown_to_next_cycle(self) -> None:
         """Display a one-line countdown before the next discovery cycle."""
 
@@ -281,7 +303,9 @@ class DlsOnvifDiscoveryEngine:  # pylint: disable=too-many-instance-attributes
 
         while self.is_discovery_running:
 
-            self.config_manager.refresh_cameras()  # Refresh camera list from config file
+            if self.config_manager is not None:
+                # Refresh camera list from config file
+                self.config_manager.refresh_cameras()
 
             current_camera_ids: set[str] = set()
 
@@ -588,7 +612,7 @@ class DlsOnvifDiscoveryEngine:  # pylint: disable=too-many-instance-attributes
         camera_ip = entry.hostname
         camera_port = entry.port
 
-        pipeline_definition = self.config_manager.get_pipeline_definition_by_ip_port(
+        pipeline_definition = self._lookup_pipeline_definition(
             camera_ip, camera_port
         )
 

--- a/python/dlstreamer/onvif/dls_onvif_events.py
+++ b/python/dlstreamer/onvif/dls_onvif_events.py
@@ -1,0 +1,968 @@
+# ==============================================================================
+# Copyright (C) 2026 Intel Corporation
+#
+# SPDX-License-Identifier: MIT
+# ==============================================================================
+"""
+ONVIF Profile S §7.7 — Event handling for *clients*.
+
+Implements the client-side requirements listed in
+*ONVIF Profile S Specification v1.3, §7.7.4 — Event Handling Function
+List for Clients*:
+
+==================================  =================  ============
+Function                            Service            Requirement
+==================================  =================  ============
+Notify                              Event              (Push path)
+Subscribe                           Event              M*
+Renew                               Event              M
+Unsubscribe                         Event              O
+SetSynchronizationPoint             Event              O
+CreatePullPointSubscription         Event              M*
+PullMessages                        Event              M (pull path)
+GetEventProperties                  Event              O
+TopicFilter                         Event              O
+MessageContentFilter                Event              O
+==================================  =================  ============
+
+\\* At least one of *Subscribe* (Base-Notification push) or
+*CreatePullPointSubscription* (PullPoint pull) MUST be implemented.
+This module implements **both** paths:
+
+* the PullPoint pull path — :class:`OnvifPullPointSubscription`
+  (Create / Pull / Renew / Unsubscribe / SetSynchronizationPoint);
+* the Base-Notification push path —
+  :meth:`OnvifEventClient.subscribe_base_notification`,
+  :meth:`OnvifEventClient.renew_base_subscription`,
+  :meth:`OnvifEventClient.unsubscribe_base_subscription`,
+  plus :class:`NotificationConsumerServer` (the embedded HTTP endpoint
+  that receives ``Notify`` SOAP POSTs) and :class:`NotifyListener`
+  (a daemon-thread combining Server + Subscribe + auto-Renew).
+
+Public API
+----------
+- :class:`OnvifEventClient` — facade over an :class:`onvif.ONVIFCamera`
+  exposing the spec functions.
+- :class:`OnvifPullPointSubscription` — context-manager wrapping one
+  pull-point subscription (Create/Pull/Renew/Unsubscribe).
+- :class:`OnvifEventListener` — background daemon-thread PullPoint pump.
+- :class:`NotificationConsumerServer` — HTTP endpoint for ``Notify``.
+- :class:`NotifyListener` — daemon-thread Base-Notification listener
+  (Subscribe + ConsumerServer + auto-Renew + Unsubscribe).
+- :class:`OnvifEvent` — parsed notification message
+  (Topic, Source, Data, UtcTime, PropertyOperation).
+- :data:`EVENT_TOPICS` — well-known Profile-S topic constants
+  (MotionAlarm, Tamper, GlobalSceneChange…).
+"""
+from __future__ import annotations
+
+import socket
+import threading
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+from typing import Any, Callable, Iterator, Optional
+
+try:
+    from lxml import etree as _etree  # type: ignore[import-not-found]
+    _HAS_LXML = True
+except ImportError:  # pragma: no cover
+    _HAS_LXML = False
+
+from onvif import ONVIFCamera  # pylint: disable=import-error
+
+
+# ---------------------------------------------------------------------------
+# Well-known Profile-S topics (§Profile S §7.7 baseline events)
+# ---------------------------------------------------------------------------
+
+EVENT_TOPICS = SimpleNamespace(
+    #: ``tns1:VideoSource/MotionAlarm`` — basic motion detection event
+    #: that every Profile-S device that signals motion MUST publish.
+    MOTION_ALARM="tns1:VideoSource/MotionAlarm",
+    #: ``tns1:VideoSource/GlobalSceneChange/ImagingService`` —
+    #: large-scale scene change (camera moved, covered, etc.).
+    GLOBAL_SCENE_CHANGE="tns1:VideoSource/GlobalSceneChange/ImagingService",
+    #: Camera tamper detected.
+    TAMPER="tns1:VideoSource/Tamper",
+    #: Wildcard subtree filter: every event under ``tns1:VideoSource``.
+    ANY_VIDEO_SOURCE="tns1:VideoSource//.",
+    #: Wildcard filter matching every event topic.
+    ANY=".//.",
+)
+
+#: TopicFilter dialect understood by every ONVIF device.
+TOPIC_DIALECT_CONCRETE = (
+    "http://docs.oasis-open.org/wsn/t-1/TopicExpression/Concrete"
+)
+
+
+# ---------------------------------------------------------------------------
+# Parsed event model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class OnvifEvent:
+    """A single notification message decoded from a PullMessages response."""
+
+    topic: str = ""
+    utc_time: Optional[datetime] = None
+    property_operation: str = ""    # ``Initialized`` / ``Changed`` / ``Deleted``
+    source: dict[str, str] = field(default_factory=dict)
+    data: dict[str, Any] = field(default_factory=dict)
+    subscription_reference: str = ""
+    producer_reference: str = ""
+
+    def __str__(self) -> str:
+        when = self.utc_time.isoformat(timespec="seconds") if self.utc_time else "?"
+        src = ",".join(f"{k}={v}" for k, v in self.source.items()) or "-"
+        dat = ",".join(f"{k}={v}" for k, v in self.data.items()) or "-"
+        op = self.property_operation or "-"
+        return f"[{when}] {self.topic}  op={op}  src=({src})  data=({dat})"
+
+
+# ---------------------------------------------------------------------------
+# Notification-message decoding helpers (zeep returns lxml elements for xsd:any)
+# ---------------------------------------------------------------------------
+
+_NS_TT = "http://www.onvif.org/ver10/schema"
+_NS_WSNT = "http://docs.oasis-open.org/wsn/b-2"
+
+
+def _local(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def _parse_iso_utc(s: str) -> Optional[datetime]:
+    if not s:
+        return None
+    try:
+        if s.endswith("Z"):
+            s = s[:-1] + "+00:00"
+        return datetime.fromisoformat(s).astimezone(timezone.utc)
+    except (ValueError, TypeError):
+        return None
+
+
+def _decode_simple_items(items_element: Any) -> dict[str, str]:
+    """Decode a ``<tt:Source>`` / ``<tt:Data>`` block into ``{Name: Value}``."""
+    out: dict[str, str] = {}
+    if items_element is None:
+        return out
+    for child in items_element:
+        if _local(child.tag) != "SimpleItem":
+            continue
+        name = child.get("Name") or ""
+        value = child.get("Value") or ""
+        if name:
+            out[name] = value
+    return out
+
+
+def _str(value: Any) -> str:
+    if value is None:
+        return ""
+    inner = getattr(value, "_value_1", None)
+    if inner is not None:
+        return str(inner)
+    return str(value)
+
+
+def _parse_notification_message(notif: Any) -> OnvifEvent:
+    """Convert one zeep ``NotificationMessage`` into :class:`OnvifEvent`."""
+    ev = OnvifEvent(
+        topic=_str(getattr(notif, "Topic", "")),
+        producer_reference=_str(
+            getattr(getattr(notif, "ProducerReference", None), "Address", "")
+        ),
+        subscription_reference=_str(
+            getattr(getattr(notif, "SubscriptionReference", None), "Address", "")
+        ),
+    )
+
+    message_wrapper = getattr(notif, "Message", None)
+    inner = getattr(message_wrapper, "_value_1", message_wrapper)
+    if inner is None or not _HAS_LXML:
+        return ev
+
+    # `inner` is an lxml.etree._Element corresponding to <tt:Message>
+    if hasattr(inner, "get"):
+        ev.utc_time = _parse_iso_utc(inner.get("UtcTime") or "")
+        ev.property_operation = inner.get("PropertyOperation") or ""
+
+        source_el = inner.find(f"{{{_NS_TT}}}Source")
+        data_el = inner.find(f"{{{_NS_TT}}}Data")
+        ev.source = _decode_simple_items(source_el)
+        ev.data = _decode_simple_items(data_el)
+    return ev
+
+
+# ---------------------------------------------------------------------------
+# Pull-point subscription
+# ---------------------------------------------------------------------------
+
+class OnvifPullPointSubscription:
+    """One ONVIF *PullPoint* subscription.
+
+    Wraps the spec functions:
+
+    - :meth:`create`                 → ``CreatePullPointSubscription`` (M\\*)
+    - :meth:`pull`                   → ``PullMessages``                 (M)
+    - :meth:`renew`                  → ``Renew``                        (M)
+    - :meth:`unsubscribe`            → ``Unsubscribe``                  (O)
+    - :meth:`set_synchronization_point`
+                                     → ``SetSynchronizationPoint``      (O)
+
+    Use as a context manager to guarantee that ``Unsubscribe`` is sent
+    when the block exits.
+    """
+
+    def __init__(
+        self,
+        camera: ONVIFCamera,
+        *,
+        topic_filter: Optional[str] = None,
+        message_content_filter: Optional[str] = None,
+        initial_termination_time: str = "PT1M",
+    ) -> None:
+        self._camera = camera
+        self._topic_filter = topic_filter
+        self._message_filter = message_content_filter
+        self._initial_termination_time = initial_termination_time
+        self._pullpoint_service: Any = None
+        self._subscription_reference: str = ""
+        self._lock = threading.RLock()
+
+    # ---- spec ops --------------------------------------------------------
+
+    def create(self) -> "OnvifPullPointSubscription":
+        """Send ``CreatePullPointSubscription`` and build the bound pull-point
+        service. Idempotent — calling twice replaces the previous binding."""
+        with self._lock:
+            events = self._camera.create_events_service()
+            req = events.create_type("CreatePullPointSubscription")
+            req.InitialTerminationTime = self._initial_termination_time
+            if self._topic_filter:
+                req.Filter = {
+                    "TopicExpression": {
+                        "_value_1": self._topic_filter,
+                        "Dialect": TOPIC_DIALECT_CONCRETE,
+                    }
+                }
+            if self._message_filter:
+                # MessageContentFilter is OPTIONAL (§7.7.4) — populated only
+                # when caller explicitly opts in.
+                req.Filter = req.Filter or {}
+                req.Filter["MessageContent"] = {
+                    "_value_1": self._message_filter,
+                    "Dialect": (
+                        "http://www.onvif.org/ver10/tev/messageContentFilter/ItemFilter"
+                    ),
+                }
+            response = events.CreatePullPointSubscription(req)
+            self._subscription_reference = _str(
+                getattr(response.SubscriptionReference, "Address", "")
+            )
+            # Bind a dedicated PullPoint service to the subscription URL.
+            self._pullpoint_service = self._camera.create_pullpoint_service()
+            self._pullpoint_service.url = self._subscription_reference
+            self._pullpoint_service.xaddr = self._subscription_reference
+            if hasattr(self._pullpoint_service, "ws_client"):
+                try:
+                    self._pullpoint_service.ws_client.set_options(
+                        location=self._subscription_reference
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pass
+            return self
+
+    def pull(
+        self,
+        *,
+        timeout: str = "PT5S",
+        max_messages: int = 32,
+    ) -> list[OnvifEvent]:
+        """Send ``PullMessages`` (§7.7.4 M). Blocks for at most *timeout*.
+
+        Parameters
+        ----------
+        timeout:
+            ISO-8601 duration string (default ``"PT5S"``); how long the
+            device may wait for an event before returning empty.
+        max_messages:
+            Hard cap on the number of messages returned per call.
+        """
+        self._require_active()
+        req = self._pullpoint_service.create_type("PullMessages")
+        req.Timeout = timeout
+        req.MessageLimit = max_messages
+        response = self._pullpoint_service.PullMessages(req)
+        notifications = getattr(response, "NotificationMessage", None) or []
+        return [_parse_notification_message(n) for n in notifications]
+
+    def renew(self, termination_time: str = "PT1M") -> None:
+        """Send ``Renew`` (§7.7.4 M) to extend the subscription lifetime."""
+        self._require_active()
+        req = self._pullpoint_service.create_type("Renew")
+        req.TerminationTime = termination_time
+        self._pullpoint_service.Renew(req)
+
+    def unsubscribe(self) -> None:
+        """Send ``Unsubscribe`` (§7.7.4 O) and forget the subscription."""
+        with self._lock:
+            svc = self._pullpoint_service
+            self._pullpoint_service = None
+            self._subscription_reference = ""
+            if svc is None:
+                return
+            try:
+                svc.Unsubscribe()
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Best-effort: device may have already expired the subscription.
+                pass
+
+    def set_synchronization_point(self) -> None:
+        """Send ``SetSynchronizationPoint`` (§7.7.4 O) — asks the device to
+        republish the current state of every property event so the client
+        can resync without waiting for the next change."""
+        self._require_active()
+        try:
+            self._pullpoint_service.SetSynchronizationPoint()
+        except Exception:  # pylint: disable=broad-exception-caught
+            # Optional per spec; some devices refuse it.
+            pass
+
+    # ---- properties ------------------------------------------------------
+
+    @property
+    def subscription_reference(self) -> str:
+        return self._subscription_reference
+
+    @property
+    def is_active(self) -> bool:
+        return self._pullpoint_service is not None
+
+    # ---- context manager -------------------------------------------------
+
+    def __enter__(self) -> "OnvifPullPointSubscription":
+        return self.create()
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.unsubscribe()
+
+    # ---- internal --------------------------------------------------------
+
+    def _require_active(self) -> None:
+        if self._pullpoint_service is None:
+            raise RuntimeError(
+                "OnvifPullPointSubscription is not active — call create() first"
+            )
+
+
+# ---------------------------------------------------------------------------
+# High-level client facade
+# ---------------------------------------------------------------------------
+
+class OnvifEventClient:
+    """Facade implementing the §7.7.4 client checklist over a single camera.
+
+    Construct from a camera entry::
+
+        client = OnvifEventClient.from_camera_entry(entry)
+
+    or from raw connection parameters::
+
+        client = OnvifEventClient("10.0.0.10", 80, "user", "pass")
+
+    Then either run the simple polling loop::
+
+        for event in client.iter_events(topic_filter=EVENT_TOPICS.MOTION_ALARM):
+            print(event)
+
+    or open a managed subscription::
+
+        with client.create_pull_point() as sub:
+            for _ in range(10):
+                for event in sub.pull(timeout="PT5S"):
+                    print(event)
+                sub.renew("PT1M")
+    """
+
+    def __init__(
+        self,
+        host: Optional[str] = None,
+        port: int = 80,
+        user: str = "",
+        password: str = "",
+        *,
+        camera: Optional[ONVIFCamera] = None,
+    ) -> None:
+        if camera is None:
+            if host is None:
+                raise ValueError("either `host` or `camera` must be supplied")
+            camera = ONVIFCamera(host, port, user, password)
+        self._camera = camera
+
+    @classmethod
+    def from_camera_entry(cls, entry: Any) -> "OnvifEventClient":
+        """Build a client from a :class:`DlsOnvifCameraEntry`."""
+        return cls(
+            host=entry.hostname,
+            port=int(entry.port or 80),
+            user=entry.username or "",
+            password=entry.password or "",
+        )
+
+    # ---- service capability ---------------------------------------------
+
+    def supports_events(self) -> bool:
+        """Return ``True`` when the device advertises the Event service.
+
+        Profile S §7.7.1 mandates the service on devices, but legacy or
+        partial implementations sometimes omit it; clients must degrade
+        gracefully.
+        """
+        try:
+            self._camera.create_events_service()
+            return True
+        except Exception:  # pylint: disable=broad-exception-caught
+            return False
+
+    # ---- §7.7.4 operations ----------------------------------------------
+
+    def get_event_properties(self) -> dict[str, Any]:
+        """Send ``GetEventProperties`` (§7.7.4 O).
+
+        Returns a dict with the keys ``TopicNamespaceLocation``,
+        ``TopicSet``, ``TopicExpressionDialect``,
+        ``MessageContentFilterDialect`` so callers can inspect what
+        topics and filter dialects the device supports before
+        subscribing.
+        """
+        events = self._camera.create_events_service()
+        response = events.GetEventProperties()
+        return {
+            "TopicNamespaceLocation": getattr(
+                response, "TopicNamespaceLocation", []
+            ) or [],
+            "FixedTopicSet": bool(getattr(response, "FixedTopicSet", False)),
+            "TopicSet": getattr(response, "TopicSet", None),
+            "TopicExpressionDialect": list(
+                getattr(response, "TopicExpressionDialect", []) or []
+            ),
+            "MessageContentFilterDialect": list(
+                getattr(response, "MessageContentFilterDialect", []) or []
+            ),
+        }
+
+    def create_pull_point(
+        self,
+        *,
+        topic_filter: Optional[str] = None,
+        message_content_filter: Optional[str] = None,
+        initial_termination_time: str = "PT1M",
+    ) -> OnvifPullPointSubscription:
+        """Build (but do not start) a :class:`OnvifPullPointSubscription`.
+
+        Use as a context manager to auto-create on entry and
+        auto-unsubscribe on exit.
+        """
+        return OnvifPullPointSubscription(
+            self._camera,
+            topic_filter=topic_filter,
+            message_content_filter=message_content_filter,
+            initial_termination_time=initial_termination_time,
+        )
+
+    def subscribe_base_notification(
+        self,
+        *,
+        consumer_reference: str,
+        topic_filter: Optional[str] = None,
+        initial_termination_time: str = "PT1M",
+    ) -> Any:
+        """Send ``Subscribe`` (§7.7.4 M\\*) — base-notification push path.
+
+        Requires the caller to host a notification consumer at
+        *consumer_reference* (an HTTP endpoint accepting ``Notify``
+        SOAP messages). Returns the raw zeep response so the caller
+        can extract the ``SubscriptionReference`` and call
+        :meth:`renew_subscription` / :meth:`unsubscribe_subscription`.
+        """
+        events = self._camera.create_events_service()
+        req = events.create_type("Subscribe")
+        req.ConsumerReference = {"Address": consumer_reference}
+        req.InitialTerminationTime = initial_termination_time
+        if topic_filter:
+            req.Filter = {
+                "TopicExpression": {
+                    "_value_1": topic_filter,
+                    "Dialect": TOPIC_DIALECT_CONCRETE,
+                }
+            }
+        return events.Subscribe(req)
+
+    def renew_base_subscription(
+        self,
+        subscription_reference: str,
+        termination_time: str = "PT1M",
+    ) -> None:
+        """Send ``Renew`` (§7.7.4 M) on a Base-Notification subscription.
+
+        *subscription_reference* is the value returned by
+        :meth:`subscribe_base_notification` (the ``Address`` field of
+        the ``SubscriptionReference`` element).
+        """
+        svc = self._camera.create_subscription_service()
+        svc.url = subscription_reference
+        svc.xaddr = subscription_reference
+        req = svc.create_type("Renew")
+        req.TerminationTime = termination_time
+        svc.Renew(req)
+
+    def unsubscribe_base_subscription(self, subscription_reference: str) -> None:
+        """Send ``Unsubscribe`` (§7.7.4 O) on a Base-Notification subscription.
+
+        Best-effort: a device that already expired the subscription will
+        return a SOAP fault, which is swallowed.
+        """
+        try:
+            svc = self._camera.create_subscription_service()
+            svc.url = subscription_reference
+            svc.xaddr = subscription_reference
+            svc.Unsubscribe()
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+    # ---- high-level pump ------------------------------------------------
+
+    def iter_events(
+        self,
+        *,
+        topic_filter: Optional[str] = None,
+        pull_timeout: str = "PT5S",
+        max_messages: int = 32,
+        max_iterations: Optional[int] = None,
+        renew_every: int = 5,
+        renew_for: str = "PT2M",
+        stop: Optional[threading.Event] = None,
+    ) -> Iterator[OnvifEvent]:
+        """Synchronous generator pulling events until *stop* or
+        *max_iterations* is reached.
+
+        Automatically renews the subscription every *renew_every* pulls.
+        Each iteration calls :meth:`OnvifPullPointSubscription.pull`;
+        every event the device returns is yielded one by one.
+        """
+        with self.create_pull_point(topic_filter=topic_filter) as sub:
+            iteration = 0
+            while True:
+                if stop is not None and stop.is_set():
+                    return
+                if max_iterations is not None and iteration >= max_iterations:
+                    return
+                events = sub.pull(timeout=pull_timeout, max_messages=max_messages)
+                for event in events:
+                    yield event
+                iteration += 1
+                if iteration % renew_every == 0:
+                    try:
+                        sub.renew(renew_for)
+                    except Exception:  # pylint: disable=broad-exception-caught
+                        # Recreate on hard failure so the loop keeps running.
+                        sub.unsubscribe()
+                        sub.create()
+
+
+# ---------------------------------------------------------------------------
+# Convenience: spin a daemon thread that pumps events into a callback.
+# ---------------------------------------------------------------------------
+
+class OnvifEventListener:
+    """Background pull-point pump.
+
+    Spawns a daemon thread that calls *callback(event)* for every
+    notification received. Stop the pump by calling :meth:`stop` —
+    the wrapped subscription is unsubscribed cleanly.
+    """
+
+    def __init__(
+        self,
+        client: OnvifEventClient,
+        callback: "Any",
+        *,
+        topic_filter: Optional[str] = None,
+        pull_timeout: str = "PT5S",
+    ) -> None:
+        self._client = client
+        self._callback = callback
+        self._topic_filter = topic_filter
+        self._pull_timeout = pull_timeout
+        self._stop = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> "OnvifEventListener":
+        if self._thread is not None and self._thread.is_alive():
+            return self
+        self._stop.clear()
+        self._thread = threading.Thread(
+            target=self._run, name="onvif-event-listener", daemon=True
+        )
+        self._thread.start()
+        return self
+
+    def _run(self) -> None:
+        try:
+            for event in self._client.iter_events(
+                topic_filter=self._topic_filter,
+                pull_timeout=self._pull_timeout,
+                stop=self._stop,
+            ):
+                try:
+                    self._callback(event)
+                except Exception:  # pylint: disable=broad-exception-caught
+                    # Never let user callback kill the pump.
+                    pass
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+    def stop(self, *, timeout: float = 8.0) -> None:
+        self._stop.set()
+        thread = self._thread
+        self._thread = None
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+
+# ---------------------------------------------------------------------------
+# Notification consumer (§7.7.4 — push path: Notify)
+# ---------------------------------------------------------------------------
+
+class _NotifyHandler(BaseHTTPRequestHandler):
+    """Embedded HTTP handler for incoming ``Notify`` SOAP POSTs.
+
+    The owning :class:`NotificationConsumerServer` is reached through
+    the ``server.notify_consumer`` attribute (set on construction).
+    """
+
+    # Silence the default per-request access log on stderr.
+    def log_message(  # noqa: A002  pylint: disable=redefined-builtin
+        self, format: str, *args: Any,
+    ) -> None:
+        return
+
+    def do_POST(self) -> None:  # noqa: N802  (BaseHTTPRequestHandler API)
+        length = int(self.headers.get("Content-Length") or "0")
+        body = self.rfile.read(length) if length > 0 else b""
+        consumer = getattr(self.server, "notify_consumer", None)
+        if consumer is not None:
+            try:
+                consumer._dispatch_envelope(body)  # pylint: disable=protected-access
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        self.send_response(200)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def do_GET(self) -> None:  # noqa: N802
+        self.send_response(405)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+
+class NotificationConsumerServer:
+    """Embedded HTTP endpoint receiving ONVIF ``Notify`` SOAP POSTs.
+
+    Implements the client side of the §7.7.4 *Notify* operation: the
+    device pushes ``Notify`` SOAP envelopes to the URL returned by
+    :attr:`consumer_reference`; every embedded
+    ``wsnt:NotificationMessage`` is decoded into an :class:`OnvifEvent`
+    and forwarded to *callback*.
+
+    The server runs in its own background thread (``ThreadingHTTPServer``)
+    so the main loop is never blocked. Both :meth:`start` and
+    :meth:`stop` are idempotent.
+    """
+
+    def __init__(
+        self,
+        callback: Callable[[OnvifEvent], None],
+        *,
+        host: str = "",
+        port: int = 0,
+        path: str = "/onvif/notify",
+        advertised_host: Optional[str] = None,
+    ) -> None:
+        self._callback = callback
+        self._bind_host = host
+        self._bind_port = port
+        self._path = path if path.startswith("/") else f"/{path}"
+        self._advertised_host = advertised_host
+        self._server: Optional[ThreadingHTTPServer] = None
+        self._thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def start(self) -> "NotificationConsumerServer":
+        """Bind the socket and start serving in a daemon thread."""
+        with self._lock:
+            if self._server is not None:
+                return self
+            srv = ThreadingHTTPServer(
+                (self._bind_host, self._bind_port), _NotifyHandler,
+            )
+            srv.notify_consumer = self  # type: ignore[attr-defined]
+            self._server = srv
+            self._thread = threading.Thread(
+                target=srv.serve_forever,
+                name="onvif-notify-consumer",
+                daemon=True,
+            )
+            self._thread.start()
+        return self
+
+    def stop(self, *, timeout: float = 4.0) -> None:
+        """Shut down the HTTP server and join its thread. Idempotent."""
+        with self._lock:
+            srv = self._server
+            thread = self._thread
+            self._server = None
+            self._thread = None
+        if srv is not None:
+            try:
+                srv.shutdown()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+            try:
+                srv.server_close()
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+        if thread is not None:
+            thread.join(timeout=timeout)
+
+    @property
+    def port(self) -> int:
+        """Bound TCP port (0 until :meth:`start` runs)."""
+        return self._server.server_port if self._server is not None else 0
+
+    @property
+    def is_running(self) -> bool:
+        return self._thread is not None and self._thread.is_alive()
+
+    @property
+    def consumer_reference(self) -> str:
+        """URL the camera should POST ``Notify`` envelopes to.
+
+        Built from the bound port plus either *advertised_host*, the
+        bind host (when explicit), or the best-effort local LAN IP.
+        Empty string until :meth:`start` runs.
+        """
+        if self._server is None:
+            return ""
+        host = self._advertised_host or self._bind_host or _autodetect_local_ip()
+        return f"http://{host}:{self.port}{self._path}"
+
+    def _dispatch_envelope(self, body: bytes) -> None:
+        """Parse a SOAP ``Notify`` body and dispatch every message."""
+        if not body or not _HAS_LXML:
+            return
+        try:
+            root = _etree.fromstring(body)  # noqa: S320  (no DTD, no external entity loading)
+        except Exception:  # pylint: disable=broad-exception-caught
+            return
+        for notif in root.iter(f"{{{_NS_WSNT}}}NotificationMessage"):
+            event = _parse_notify_xml_message(notif)
+            try:
+                self._callback(event)
+            except Exception:  # pylint: disable=broad-exception-caught
+                pass
+
+
+def _autodetect_local_ip() -> str:
+    """Best-effort LAN IP for the SubscriptionReference URL."""
+    try:
+        with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sk:
+            sk.connect(("8.8.8.8", 80))
+            return sk.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+
+
+def _parse_notify_xml_message(notif: Any) -> OnvifEvent:
+    """Convert one ``wsnt:NotificationMessage`` lxml node into an OnvifEvent."""
+    ev = OnvifEvent()
+    topic_el = notif.find(f"{{{_NS_WSNT}}}Topic")
+    if topic_el is not None and topic_el.text:
+        ev.topic = topic_el.text.strip()
+    producer_el = notif.find(f"{{{_NS_WSNT}}}ProducerReference")
+    if producer_el is not None:
+        addr = producer_el.find("{http://www.w3.org/2005/08/addressing}Address")
+        if addr is not None and addr.text:
+            ev.producer_reference = addr.text.strip()
+    sub_el = notif.find(f"{{{_NS_WSNT}}}SubscriptionReference")
+    if sub_el is not None:
+        addr = sub_el.find("{http://www.w3.org/2005/08/addressing}Address")
+        if addr is not None and addr.text:
+            ev.subscription_reference = addr.text.strip()
+
+    msg_wrapper = notif.find(f"{{{_NS_WSNT}}}Message")
+    if msg_wrapper is None:
+        return ev
+    inner = msg_wrapper.find(f"{{{_NS_TT}}}Message")
+    if inner is None:
+        inner = msg_wrapper[0] if len(msg_wrapper) else None
+    if inner is None or not hasattr(inner, "get"):
+        return ev
+    ev.utc_time = _parse_iso_utc(inner.get("UtcTime") or "")
+    ev.property_operation = inner.get("PropertyOperation") or ""
+    source_el = inner.find(f"{{{_NS_TT}}}Source")
+    data_el = inner.find(f"{{{_NS_TT}}}Data")
+    ev.source = _decode_simple_items(source_el)
+    ev.data = _decode_simple_items(data_el)
+    return ev
+
+
+# ---------------------------------------------------------------------------
+# NotifyListener — daemon-thread Base-Notification listener
+# ---------------------------------------------------------------------------
+
+class NotifyListener:
+    """High-level Base-Notification push pump.
+
+    Combines :class:`NotificationConsumerServer` with
+    :meth:`OnvifEventClient.subscribe_base_notification` and a periodic
+    ``Renew`` heart-beat. Use as a context manager or call
+    :meth:`start` / :meth:`stop` explicitly.
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        client: OnvifEventClient,
+        callback: Callable[[OnvifEvent], None],
+        *,
+        topic_filter: Optional[str] = None,
+        initial_termination_time: str = "PT2M",
+        renew_every_s: float = 60.0,
+        renew_for: str = "PT2M",
+        consumer_host: str = "",
+        consumer_port: int = 0,
+        consumer_path: str = "/onvif/notify",
+        advertised_host: Optional[str] = None,
+    ) -> None:
+        self._client = client
+        self._callback = callback
+        self._topic_filter = topic_filter
+        self._initial_termination_time = initial_termination_time
+        self._renew_every_s = max(1.0, float(renew_every_s))
+        self._renew_for = renew_for
+        self._server = NotificationConsumerServer(
+            self._on_event,
+            host=consumer_host,
+            port=consumer_port,
+            path=consumer_path,
+            advertised_host=advertised_host,
+        )
+        self._subscription_reference: str = ""
+        self._stop = threading.Event()
+        self._renew_thread: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+
+    def start(self) -> "NotifyListener":
+        """Start the consumer server, send ``Subscribe`` and spawn the
+        renew thread. Raises if the device rejects the subscription."""
+        with self._lock:
+            if self._renew_thread is not None and self._renew_thread.is_alive():
+                return self
+            self._stop.clear()
+            self._server.start()
+            response = self._client.subscribe_base_notification(
+                consumer_reference=self._server.consumer_reference,
+                topic_filter=self._topic_filter,
+                initial_termination_time=self._initial_termination_time,
+            )
+            self._subscription_reference = _str(
+                getattr(getattr(response, "SubscriptionReference", None), "Address", "")
+            )
+            self._renew_thread = threading.Thread(
+                target=self._renew_loop,
+                name="onvif-notify-renew",
+                daemon=True,
+            )
+            self._renew_thread.start()
+        return self
+
+    def stop(self, *, timeout: float = 4.0) -> None:
+        """Unsubscribe, stop the renew thread and the consumer server."""
+        self._stop.set()
+        with self._lock:
+            renew_thread = self._renew_thread
+            self._renew_thread = None
+            sub_ref = self._subscription_reference
+            self._subscription_reference = ""
+        if renew_thread is not None:
+            renew_thread.join(timeout=timeout)
+        if sub_ref:
+            self._client.unsubscribe_base_subscription(sub_ref)
+        self._server.stop(timeout=timeout)
+
+    def __enter__(self) -> "NotifyListener":
+        return self.start()
+
+    def __exit__(self, *_exc: Any) -> None:
+        self.stop()
+
+    @property
+    def consumer_reference(self) -> str:
+        return self._server.consumer_reference
+
+    @property
+    def subscription_reference(self) -> str:
+        return self._subscription_reference
+
+    @property
+    def is_running(self) -> bool:
+        return self._renew_thread is not None and self._renew_thread.is_alive()
+
+    def _on_event(self, event: OnvifEvent) -> None:
+        try:
+            self._callback(event)
+        except Exception:  # pylint: disable=broad-exception-caught
+            pass
+
+    def _renew_loop(self) -> None:
+        while not self._stop.wait(self._renew_every_s):
+            sub_ref = self._subscription_reference
+            if not sub_ref:
+                return
+            try:
+                self._client.renew_base_subscription(sub_ref, self._renew_for)
+            except Exception:  # pylint: disable=broad-exception-caught
+                # Re-subscribe if the device dropped us.
+                try:
+                    response = self._client.subscribe_base_notification(
+                        consumer_reference=self._server.consumer_reference,
+                        topic_filter=self._topic_filter,
+                        initial_termination_time=self._initial_termination_time,
+                    )
+                    self._subscription_reference = _str(
+                        getattr(getattr(response, "SubscriptionReference", None),
+                                "Address", "")
+                    )
+                except Exception:  # pylint: disable=broad-exception-caught
+                    pass
+
+
+__all__ = [
+    "EVENT_TOPICS",
+    "TOPIC_DIALECT_CONCRETE",
+    "OnvifEvent",
+    "OnvifEventClient",
+    "OnvifEventListener",
+    "OnvifPullPointSubscription",
+    "NotificationConsumerServer",
+    "NotifyListener",
+]


### PR DESCRIPTION
## Summary

First iteration of the ONVIF stack refactor. The previous monolithic implementation is decomposed into three cleanly separated components with well-defined responsibilities and a single public entry point.

## What's in this PR

Three new top-level components under `python/dlstreamer/`:

| Component | Path | Role |
|---|---|---|
| **Plugin** | `python/dlstreamer/onvif-plugin/` | GStreamer plugin `dlsonvif` — a thin C shim (`libgstdlsonvif.so`) plus a Python `onvifdeviceprovider` device provider and a `dlsonvifsrc_py` source element |
| **Library** | `python/dlstreamer/onvif/` | Reusable Python library exposing the 13-function Public API (`dlstreamer.onvif`) — WS-Discovery, ONVIF profile queries, credentials, event subscriptions (pull & push) |
| **Sample app** | `python/dlstreamer/onvif-plugin-sample-app/` | End-to-end demo consuming the library only through its Public API: continuous discovery loop, RTSP playback, per-camera JPEG snapshots, Profile S §7.7.4 event subscriptions |

## What the sample app can do

- `--interval N` — periodic state dump of all discovered cameras
- `--play TOKEN` — RTSP playback of a chosen profile
- `--snapshot DIR` — one JPEG per camera per tick
- `--user / --password / --xaddr` — inject credentials into a specific device
- `--watch-events` / `--notify` — Profile S §7.7.4 pull or push event subscriptions
- `--headless` / `--once` — CI-friendly modes

See `python/dlstreamer/onvif-plugin-sample-app/README.md` for full CLI reference, usage scenarios, troubleshooting, and Mermaid flow / sequence diagrams.

## How to try it

```bash
cd dlstreamer
source python3venv/bin/activate
source scripts/setup_dls_env.sh
export GST_PLUGIN_PATH="$PWD/python/dlstreamer/onvif-plugin:$GST_PLUGIN_PATH"
export PYTHONPATH="$PWD/python:$PYTHONPATH"

# sanity check — plugin visible?
gst-inspect-1.0 dlsonvif | head

# run the sample app
python python/dlstreamer/onvif-plugin-sample-app/app.py --interval 3
```

## Checklist

- [ ] Plugin loads under `gst-inspect-1.0 dlsonvif`
- [ ] Sample app discovers cameras on the LAN
- [ ] `--play`, `--snapshot`, `--watch-events`, `--notify` all functional
- [ ] Documentation (`README.md` in plugin and sample-app dirs) up to date
- [ ] No changes to unrelated DL Streamer code
