### PR TITLE
[GST WATERMARK] support gvawatermark blurring on GPU

### DIFF
--- a/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/gstgvawatermarkimpl.cpp
@@ -134,7 +134,7 @@ struct Impl {
     bool extract_primitives(GstBuffer *buffer);
     int get_num_primitives() const;
     bool render(GstBuffer *buffer);
-    bool render_va(cv::Mat *buffer);
+    [[nodiscard]] bool render_va(cv::Mat *overlay, cv::UMat *frame);
     const std::string &getBackendType() const {
         return _backend_type;
     }
@@ -630,25 +630,30 @@ static GstFlowReturn gst_gva_watermark_impl_transform_ip(GstBaseTransform *trans
 
                     gvawatermark->overlay_cpu.create(height, width, CV_8UC3);
                     gvawatermark->overlay_ready = true;
-                    GST_INFO_OBJECT(gvawatermark, "Allocated CPU overlay (%dx%d CV_8UC4)", width, height);
+                    GST_INFO_OBJECT(gvawatermark, "Allocated CPU overlay (%dx%d CV_8UC3)", width, height);
                 }
 
                 // Clear only once per frame (fast memset on host)
                 gvawatermark->overlay_cpu.setTo(cv::Scalar(0, 0, 0, 0));
 
-                cv::UMat u;
-                cv::va_intel::convertFromVASurface(gvawatermark->va_dpy, sid, cv::Size(width, height), u);
+                if (!cv::ocl::useOpenCL()) {
+                    GST_WARNING_OBJECT(gvawatermark, "OpenCL not available; skipping GPU render for this frame");
+                    use_gpu_path = false;
+                } else {
+                    cv::UMat u;
+                    cv::va_intel::convertFromVASurface(gvawatermark->va_dpy, sid, cv::Size(width, height), u);
 
-                gvawatermark->impl->render_va(&(gvawatermark->overlay_cpu));
+                    bool has_overlay = gvawatermark->impl->render_va(&(gvawatermark->overlay_cpu), &u);
 
-                // Upload once (host -> UMat). OpenCL runtime can keep it on device afterward.
-                gvawatermark->overlay_cpu.copyTo(gvawatermark->overlay_gpu);
+                    if (has_overlay) {
+                        // Upload once (host -> UMat). OpenCL runtime can keep it on device afterward.
+                        gvawatermark->overlay_cpu.copyTo(gvawatermark->overlay_gpu);
 
-                if (cv::ocl::useOpenCL()) {
-                    cv::UMat gray, mask;
-                    cv::cvtColor(gvawatermark->overlay_gpu, gray, cv::COLOR_BGR2GRAY);
-                    cv::threshold(gray, mask, 0, 255, cv::THRESH_BINARY);
-                    gvawatermark->overlay_gpu.copyTo(u, mask);
+                        cv::UMat gray, mask;
+                        cv::cvtColor(gvawatermark->overlay_gpu, gray, cv::COLOR_BGR2GRAY);
+                        cv::threshold(gray, mask, 0, 255, cv::THRESH_BINARY);
+                        gvawatermark->overlay_gpu.copyTo(u, mask);
+                    }
 
                     cv::va_intel::convertToVASurface(gvawatermark->va_dpy, u, sid, cv::Size(width, height));
                 }
@@ -901,15 +906,40 @@ bool Impl::render(GstBuffer *buffer) {
     return true;
 }
 
-bool Impl::render_va(cv::Mat *buffer) {
+bool Impl::render_va(cv::Mat *overlay, cv::UMat *frame) {
     ITT_TASK(__FUNCTION__);
 
-    // Skip render if there are no primitives to draw
-    if (!prims.empty()) {
-        _renderer_opencv->draw_va(*buffer, prims);
+    if (prims.empty())
+        return false;
+
+    // Apply blur directly on the GPU-resident UMat frame (via OpenCL T-API).
+    // Blur must happen before overlay compositing — it modifies existing pixels,
+    // which the black-overlay + binary-mask approach cannot express.
+    bool has_overlay_prims = false;
+    for (auto it = prims.begin(); it != prims.end();) {
+        if (std::holds_alternative<render::Blur>(*it)) {
+            const auto &blur = std::get<render::Blur>(*it);
+            cv::Rect r = blur.rect;
+            if (r.width <= 0 || r.height <= 0) {
+                it = prims.erase(it);
+                continue;
+            }
+            cv::Size ksize = render::computeBlurKernelSize(r.width, r.height);
+            cv::UMat roi(*frame, r);
+            cv::GaussianBlur(roi, roi, ksize, 0, 0);
+            it = prims.erase(it);
+        } else {
+            has_overlay_prims = true;
+            ++it;
+        }
     }
 
-    return true;
+    // Render remaining (non-blur) primitives onto the CPU overlay
+    if (has_overlay_prims) {
+        _renderer_opencv->draw_va(*overlay, prims);
+    }
+
+    return has_overlay_prims;
 }
 
 inline bool Impl::is_ROI_filtered_out(const std::string &label) const {

--- a/src/monolithic/gst/elements/gvawatermark/renderer/cpu/renderer_cpu.cpp
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/cpu/renderer_cpu.cpp
@@ -12,16 +12,6 @@
 
 namespace {
 
-// Compute a Gaussian blur kernel size proportional to the ROI so that larger
-// regions get a stronger blur.  The kernel must be positive and odd for
-// cv::GaussianBlur.  Using ~1/3 of each dimension with a minimum of 7
-// keeps small objects blurred while scaling up for bigger regions.
-cv::Size computeBlurKernelSize(int roi_width, int roi_height) {
-    int kw = std::max(7, roi_width / 3) | 1;  // Ensure odd
-    int kh = std::max(7, roi_height / 3) | 1; // Ensure odd
-    return cv::Size(kw, kh);
-}
-
 const std::vector<cv::Vec3b> PascalVoc21ClColorPalette = {
     cv::Vec3b(0, 0, 0),       // background
     cv::Vec3b(128, 0, 0),     // aeroplane
@@ -155,8 +145,8 @@ void RendererI420::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur)
     cv::Mat &v = mats[2];
 
     cv::Rect r = blur.rect;
-    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
-    cv::Size ksize_uv = computeBlurKernelSize(r.width / 2, r.height / 2);
+    cv::Size ksize = render::computeBlurKernelSize(r.width, r.height);
+    cv::Size ksize_uv = render::computeBlurKernelSize(r.width / 2, r.height / 2);
 
     cv::Mat roi_u(u, cv::Rect(r.x / 2, r.y / 2, r.width / 2, r.height / 2));
     cv::GaussianBlur(roi_u, roi_u, ksize_uv, 0, 0);
@@ -294,8 +284,8 @@ void RendererNV12::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur)
     cv::Mat &u_v = mats[1];
 
     cv::Rect r = blur.rect;
-    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
-    cv::Size ksize_uv = computeBlurKernelSize(r.width / 2, r.height / 2);
+    cv::Size ksize = render::computeBlurKernelSize(r.width, r.height);
+    cv::Size ksize_uv = render::computeBlurKernelSize(r.width / 2, r.height / 2);
 
     cv::Mat roi_uv(u_v, cv::Rect(r.x / 2, r.y / 2, r.width / 2, r.height / 2));
     cv::GaussianBlur(roi_uv, roi_uv, ksize_uv, 0, 0);
@@ -471,7 +461,7 @@ void RendererBGR::draw_rectangle(std::vector<cv::Mat> &mats, render::Rect rect) 
 void RendererBGR::blur_rectangle(std::vector<cv::Mat> &mats, render::Blur blur) {
     cv::Mat &mat = mats[0];
     cv::Rect r = blur.rect;
-    cv::Size ksize = computeBlurKernelSize(r.width, r.height);
+    cv::Size ksize = render::computeBlurKernelSize(r.width, r.height);
     cv::Mat roi(mat, cv::Rect(r.x, r.y, r.width, r.height));
     cv::GaussianBlur(roi, roi, ksize, 0, 0);
 }

--- a/src/monolithic/gst/elements/gvawatermark/renderer/render_prim.h
+++ b/src/monolithic/gst/elements/gvawatermark/renderer/render_prim.h
@@ -114,6 +114,14 @@ struct Blur {
     }
 };
 
+// Compute Gaussian blur kernel size proportional to ROI dimensions.
+// Kernel is ~1/3 of each dimension, minimum 7, always odd.
+inline cv::Size computeBlurKernelSize(int roi_width, int roi_height) {
+    int kw = std::max(7, roi_width / 3) | 1;
+    int kh = std::max(7, roi_height / 3) | 1;
+    return cv::Size(kw, kh);
+}
+
 using Prim = std::variant<Text, Rect, Circle, Line, Polygon, InstanceSegmantationMask, SemanticSegmantationMask, Blur>;
 
 } // namespace render


### PR DESCRIPTION
### Description

Enable GaussianBlur on VA surface (GPU) path in gvawatermark, allowing object blurring without falling back to CPU when the pipeline uses hardware-accelerated decode/encode.

### How Has This Been Tested?

using gstreamer pipeline :

gst-launch-1.0 filesrc location=`input_video.mp4` ! parsebin ! vah264dec ! gvadetect model=`model.xml` device=GPU pre-process-backend=va-surface-sharing ! gvawatermark device=GPU displ-cfg="enable-blur=true" ! vah264enc ! h264parse ! mp4mux ! filesink location=`output_video.mp4`

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

