### PR TITLE
Fix HTTP Error 403: Forbidden in Python samples

### DIFF
--- a/samples/gstreamer/python/vlm_alerts/vlm_alerts.py
+++ b/samples/gstreamer/python/vlm_alerts/vlm_alerts.py
@@ -47,8 +47,12 @@ def download_video(url: str, target_path: Path) -> None:
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.hostname not in {"videos.pexels.com", "www.pexels.com"}:
         raise VLMAlertsError(f"Unexpected video URL: {url}")
+    # Some CDNs (e.g. Pexels) reject the default ``Python-urllib`` agent with HTTP 403,
+    # so present a common browser User-Agent instead.
+    user_agent = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+    request = urllib.request.Request(url, headers={"User-Agent": user_agent})
     try:
-        with urllib.request.build_opener().open(url, timeout=30) as response, open(target_path, "wb") as file:
+        with urllib.request.build_opener().open(request, timeout=30) as response, open(target_path, "wb") as file:
             shutil.copyfileobj(response, file)
     except (OSError, ValueError) as error:
         raise VLMAlertsError(f"Video download failed: {error}") from error

--- a/samples/shared_utils.py
+++ b/samples/shared_utils.py
@@ -9,13 +9,18 @@ import shutil
 import urllib.request
 from urllib.parse import urlparse
 
+# Some CDNs (e.g. Pexels) reject the default ``Python-urllib`` agent with HTTP 403,
+# so present a common browser User-Agent instead.
+_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36"
+
 
 def download_https(url, destination, allowed_hosts, timeout=60):
     """Stream an HTTPS URL to ``destination``; reject non-allowlisted hosts."""
     parsed = urlparse(url)
     if parsed.scheme != "https" or parsed.hostname not in allowed_hosts:
         raise ValueError(f"Refusing non-allowlisted URL: {url}")
-    with urllib.request.build_opener().open(url, timeout=timeout) as response, open(destination, "wb") as output:
+    request = urllib.request.Request(url, headers={"User-Agent": _USER_AGENT})
+    with urllib.request.build_opener().open(request, timeout=timeout) as response, open(destination, "wb") as output:
         shutil.copyfileobj(response, output)
 
 


### PR DESCRIPTION
### Description

The `HTTP Error 403: Forbidden` error is thrown in DL Streamer Python samples. It can be seen in Smart NVR, Face Detection and Classification and probably in VLM Alert samples. The 403 is because Pexels rejects requests with the default [Python-urllib/3.x User-Agent. The fix belongs in download_https — send a browser-like User-Agent header.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

