### PR TITLE
Add I420 and YV12 support for system memory (gvamotiondetect)

### DIFF
--- a/src/monolithic/gst/elements/gvamotiondetect/gvamotiondetect.cpp
+++ b/src/monolithic/gst/elements/gvamotiondetect/gvamotiondetect.cpp
@@ -230,11 +230,11 @@ G_DEFINE_TYPE(GstGvaMotionDetect, gst_gva_motion_detect, GST_TYPE_BASE_TRANSFORM
 static GstStaticPadTemplate sink_templ =
     GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
                             GST_STATIC_CAPS("video/x-raw(memory:VAMemory), format=NV12; "
-                                            "video/x-raw, format=NV12"));
+                                            "video/x-raw, format={ NV12, I420, YV12 }"));
 static GstStaticPadTemplate src_templ =
     GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
                             GST_STATIC_CAPS("video/x-raw(memory:VAMemory), format=NV12; "
-                                            "video/x-raw, format=NV12"));
+                                            "video/x-raw, format={ NV12, I420, YV12 }"));
 
 static void gst_gva_motion_detect_set_context(GstElement *elem, GstContext *context) {
     GstGvaMotionDetect *self = GST_GVA_MOTION_DETECT(elem);
@@ -929,7 +929,9 @@ static void gst_gva_motion_detect_class_init(GstGvaMotionDetectClass *klass) {
 
     gst_element_class_set_static_metadata(
         eclass, "Motion detect (auto GPU/CPU)", "Filter/Video",
-        "Automatically uses VA surface path when VAMemory caps negotiated; otherwise system memory path", "dlstreamer");
+        "Operates on the luma plane; accepts NV12 / I420 / YV12 system-memory input and NV12 VAMemory input. "
+        "Automatically uses VA surface path when VAMemory caps negotiated; otherwise system memory path",
+        "dlstreamer");
 
     gst_element_class_add_static_pad_template(eclass, &sink_templ);
     gst_element_class_add_static_pad_template(eclass, &src_templ);

--- a/src/monolithic/gst/elements/gvamotiondetect/gvamotiondetect_win.cpp
+++ b/src/monolithic/gst/elements/gvamotiondetect/gvamotiondetect_win.cpp
@@ -731,11 +731,11 @@ static void gst_gva_motion_detect_class_init(GstGvaMotionDetectClass *klass) {
     static GstStaticPadTemplate sink_templ =
         GST_STATIC_PAD_TEMPLATE("sink", GST_PAD_SINK, GST_PAD_ALWAYS,
                                 GST_STATIC_CAPS("video/x-raw(memory:D3D11Memory), format=NV12; "
-                                                "video/x-raw, format=NV12"));
+                                                "video/x-raw, format={ NV12, I420, YV12 }"));
     static GstStaticPadTemplate src_templ =
         GST_STATIC_PAD_TEMPLATE("src", GST_PAD_SRC, GST_PAD_ALWAYS,
                                 GST_STATIC_CAPS("video/x-raw(memory:D3D11Memory), format=NV12; "
-                                                "video/x-raw, format=NV12"));
+                                                "video/x-raw, format={ NV12, I420, YV12 }"));
     gst_element_class_add_static_pad_template(eclass, &sink_templ);
     gst_element_class_add_static_pad_template(eclass, &src_templ);
     eclass->set_context = gst_gva_motion_detect_set_context;


### PR DESCRIPTION
### Description

Adds support for I420 and YV12 pixel formats to the `gvamotiondetect` element's system-memory (CPU) path on both Linux and Windows. Previously the element only accepted `NV12` for system-memory inputs, requiring an explicit `videoconvert` step upstream when working with CPU-decoded video (e.g. from `avdec_h264`). This change updates the sink/src pad templates to advertise `{ NV12, I420, YV12 }` for `video/x-raw`, while the hardware-accelerated paths (`VAMemory` on Linux, `D3D11Memory` on Windows) remain restricted to `NV12`. The element description metadata is updated accordingly.

Closes: #914

### Any Newly Introduced Dependencies

None. No new third-party components are introduced.

### How Has This Been Tested?

Tested with `gst-launch-1.0` on Linux using `videotestsrc` with I420 format:

```bash
gst-launch-1.0 -v videotestsrc num-buffers=120 pattern=ball \
  ! video/x-raw,format=I420,width=640,height=480 \
  ! gvamotiondetect \
  ! fakesink
```
### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

