### PR TITLE
Keep env vars (like proxy) when adding Intel GPU PPA repository

### DIFF
--- a/scripts/DLS_install_prerequisites.sh
+++ b/scripts/DLS_install_prerequisites.sh
@@ -287,7 +287,7 @@ setup_gpu(){
     if [ "$ubuntu_version" == "24.04" ]; then
         echo "Installing GPU drivers for Ubuntu 24.04..."
         $SUDO_PREFIX apt-get install -y --no-install-recommends software-properties-common || handle_error "Failed to install software-properties-common"
-        $SUDO_PREFIX add-apt-repository -y "$INTEL_CL_GPU_REPO_URL" || handle_error "Failed to add Intel GPU repository"
+        $SUDO_PREFIX -E add-apt-repository -y "$INTEL_CL_GPU_REPO_URL" || handle_error "Failed to add Intel GPU repository"
         $SUDO_PREFIX apt update || handle_error "Failed to update package lists after adding repository"
         echo "Snapshot: 20260624T030400Z" | $SUDO_PREFIX tee -a "/etc/apt/sources.list.d/$INTEL_GPU_LIST" || handle_error "Failed to add snapshot information"
         $SUDO_PREFIX apt update || handle_error "Failed to update package lists after adding snapshot"


### PR DESCRIPTION
### Description

In environment behind corporate proxy, when env was not passed to sudo process, on fresh install of Ubuntu 24.04.4, and proxy settings set in GUI system settings, all other operations (including earlier apt's) were working fine. But here on adding ppa repo it was hanging and failing with timeout eventually (with "Error occurred: Failed to add Intel GPU repository").

Fixes # (issue) - see in description below

### Any Newly Introduced Dependencies

n/a

### How Has This Been Tested?

Install fresh Ubuntu 24.04.4 in network behind proxy.
Configure proxy in Settings > Network > Proxy (Manual)
Then follow https://docs.openedgeplatform.intel.com/dev/edge-ai-libraries/dlstreamer/get_started/install/install_guide_ubuntu.html#prerequisites

```
mkdir -p ~/intel/dlstreamer_gst
cd ~/intel/dlstreamer_gst/
wget -O DLS_install_prerequisites.sh https://raw.githubusercontent.com/open-edge-platform/dlstreamer/main/scripts/DLS_install_prerequisites.sh && chmod +x DLS_install_prerequisites.sh

./DLS_install_prerequisites.sh
# here it would hang
```

<details>

<summary>Full log on hang</summary>

```
$ ./DLS_install_prerequisites.sh
Reinstall NPU driver: no
This script will install the necessary GPU and NPU drivers that have been tested and verified to work with DLStreamer.

 CPU is (Intel(R) Core(TM) Ultra 9 285H).

 Detected Ubuntu version: 24.04.

 The script will now update package lists and install required packages.
[sudo] password for kkepka:
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
The following packages were automatically installed and are no longer required:
  libfwupd2 libwoff1
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.
Hit:1 http://archive.ubuntu.com/ubuntu noble InRelease
Hit:2 http://archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:3 http://security.ubuntu.com/ubuntu noble-security InRelease
Hit:4 http://archive.ubuntu.com/ubuntu noble-backports InRelease
Reading package lists...
 Package lists updated successfully.
 Installing packages: curl wget jq gpg pciutils software-properties-common.
Reading package lists...
Building dependency tree...
Reading state information...
wget is already the newest version (1.21.4-1ubuntu4.3).
wget set to manually installed.
jq is already the newest version (1.7.1-3ubuntu0.24.04.2).
jq set to manually installed.
gpg is already the newest version (2.4.4-2ubuntu17.4).
gpg set to manually installed.
pciutils is already the newest version (1:3.10.0-2build1).
pciutils set to manually installed.
software-properties-common is already the newest version (0.99.49.4).
software-properties-common set to manually installed.
The following packages were automatically installed and are no longer required:
  libfwupd2 libwoff1
Use 'sudo apt autoremove' to remove them.
The following NEW packages will be installed:
  curl
0 upgraded, 1 newly installed, 0 to remove and 0 not upgraded.
Need to get 226 kB of archives.
After this operation, 535 kB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu noble-updates/main amd64 curl amd64 8.5.0-2ubuntu10.11 [226 kB]
Fetched 226 kB in 1s (160 kB/s)
Selecting previously unselected package curl.
(Reading database ... 193765 files and directories currently installed.)
Preparing to unpack .../curl_8.5.0-2ubuntu10.11_amd64.deb ...
Unpacking curl (8.5.0-2ubuntu10.11) ...
Setting up curl (8.5.0-2ubuntu10.11) ...
Processing triggers for man-db (2.12.0-4build2) ...
 Installed curl wget jq gpg pciutils software-properties-common successfully.

 Intel® Client GPU detected:
 --------------------------------
 00:02.0 VGA compatible controller [0300]: Intel Corporation Arrow Lake-P [Intel Graphics] [8086:7d51] (rev 03)
 --------------------------------

 ✓ Intel® Client GPU detected! We'll automatically install the optimized GPU drivers for your system.

Updating package lists...
Hit:1 http://security.ubuntu.com/ubuntu noble-security InRelease
Hit:2 http://archive.ubuntu.com/ubuntu noble InRelease
Hit:3 http://archive.ubuntu.com/ubuntu noble-updates InRelease
Hit:4 http://archive.ubuntu.com/ubuntu noble-backports InRelease
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
All packages are up to date.
Installing GPU drivers for Ubuntu 24.04...
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
software-properties-common is already the newest version (0.99.49.4).
The following packages were automatically installed and are no longer required:
  libfwupd2 libwoff1
Use 'sudo apt autoremove' to remove them.
0 upgraded, 0 newly installed, 0 to remove and 0 not upgraded.

Traceback (most recent call last):
  File "/usr/bin/add-apt-repository", line 452, in <module>
    sys.exit(0 if addaptrepo.main() else 1)
                  ^^^^^^^^^^^^^^^^^
  File "/usr/bin/add-apt-repository", line 435, in main
    shortcut = handler(source, **shortcut_params)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/softwareproperties/shortcuts.py", line 40, in shortcut_handler
    return handler(shortcut, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 89, in __init__
    if self.lpppa.publish_debug_symbols:
       ^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 133, in lpppa
    self._lpppa = self.lpteam.getPPAByName(name=self.ppaname)
                  ^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 120, in lpteam
    self._lpteam = self.lp.people(self.teamname)
                   ^^^^^^^
  File "/usr/lib/python3/dist-packages/softwareproperties/ppa.py", line 111, in lp
    self._lp = login_func("%s.%s" % (self.__module__, self.__class__.__name__),
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 494, in login_anonymously
    return cls(
           ^^^^
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 230, in __init__
    super(Launchpad, self).__init__(
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/resource.py", line 511, in __init__
    self._wadl = self._browser.get_wadl_application(self._root_uri)
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 502, in get_wadl_application
    response, content = self._request(url, media_type=wadl_type)
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 441, in _request
    response, content = self._request_and_retry(
                        ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 400, in _request_and_retry
    response, content = self._connection.request(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1732, in request
    (response, content) = self._request(
                          ^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/launchpadlib/launchpad.py", line 144, in _request
    response, content = super(LaunchpadOAuthAwareHttp, self)._request(
                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/lazr/restfulclient/_browser.py", line 204, in _request
    return super(RestfulHttp, self)._request(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1452, in _request
    (response, content) = self._conn_request(conn, request_uri, method, body, headers)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1374, in _conn_request
    conn.connect()
  File "/usr/lib/python3/dist-packages/httplib2/__init__.py", line 1139, in connect
    sock.connect((self.host, self.port))
TimeoutError: [Errno 110] Connection timed out
Error occurred: Failed to add Intel GPU repository

```

</details>

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

