### PR TITLE
g3dinference: Change g3dinference default threshold from 0.0 to 0.7

### DIFF
--- a/docs/user-guide/elements/g3dinference.md
+++ b/docs/user-guide/elements/g3dinference.md
@@ -19,7 +19,7 @@ Key operations:
 | config | String | Path to the PointPillars JSON configuration file. Required. | null |
 | device | String | OpenVINO device used for the neural network stage. Currently `CPU`, `GPU`, and `GPU.<id>` are supported. | CPU |
 | model-type | String | 3D detector model type. Currently only `pointpillars` is supported. | pointpillars |
-| score-threshold | Float | Drops detections below this score. `0.0` keeps all post-processing output unchanged. | 0.0 |
+| score-threshold | Float | Drops detections below this score. `0.0` keeps all post-processing output unchanged. | 0.7 |
 
 ## Configuration
 
@@ -171,5 +171,5 @@ Element Properties:
   score-threshold     : Drop detections below this score (0 keeps all postproc output)
                         flags: readable, writable
                         Float. Range:               0 - 1 
-                        Default:               0
+                        Default:               0.7
 ```

--- a/samples/gstreamer/gst_launch/g3dinference/README.md
+++ b/samples/gstreamer/gst_launch/g3dinference/README.md
@@ -22,7 +22,7 @@ The default pipeline is:
 gst-launch-1.0 -e \
 	multifilesrc location=".../%06d.bin" start-index=2 stop-index=2 caps=application/octet-stream ! \
 	g3dlidarparse ! \
-	g3dinference config=".../pointpillars_ov_config.json" device=CPU score-threshold=0 ! \
+	g3dinference config=".../pointpillars_ov_config.json" device=CPU score-threshold=0.7 ! \
 	gvametaconvert format=json json-indent=2 ! \
 	gvametapublish file-format=2 file-path=".../g3dinference_output.json" ! \
 	fakesink
@@ -31,7 +31,7 @@ gst-launch-1.0 -e \
 `g3dlidarparse` converts the raw point cloud into `application/x-lidar` with `LidarMeta`. `g3dinference` loads the PointPillars runtime from the generated JSON config, runs inference, and attaches metadata. `gvametaconvert` and `gvametapublish` serialize that metadata to JSON.
 Use `multifilesrc` even for a single frame, because `filesrc` may split the input into block-sized chunks.
 The `device` setting currently supports `CPU`, `GPU`, and `GPU.<id>`.
-The `score-threshold` setting uses `0` to keep all post-processing output unchanged.
+The `score-threshold` setting defaults to `0.7`; set it to `0` to keep all post-processing output unchanged.
 
 ## Prerequisites
 

--- a/samples/gstreamer/gst_launch/g3dinference/g3dinference.sh
+++ b/samples/gstreamer/gst_launch/g3dinference/g3dinference.sh
@@ -26,7 +26,7 @@ Arguments:
 									 Default: .pointpillars/data/000002.bin
 	DEVICE           Optional. OpenVINO device for g3dinference. Supported values: CPU, GPU, GPU.<id>. Default: CPU
 	OUTPUT_JSON      Optional. JSON output path. Default: .pointpillars/g3dinference_output.json
-	SCORE_THRESHOLD  Optional. Minimum score threshold. Default: 0
+	SCORE_THRESHOLD  Optional. Minimum score threshold. Default: 0.7
 
 Environment:
 	POINTPILLARS_CACHE_DIR    Cache directory containing prepared data/config
@@ -46,7 +46,7 @@ fi
 SOURCE_INPUT="${1:-${DATA_DIR}/000002.bin}"
 DEVICE="${2:-CPU}"
 OUTPUT_JSON="${3:-${POINTPILLARS_CACHE_DIR}/g3dinference_output.json}"
-SCORE_THRESHOLD="${4:-0}"
+SCORE_THRESHOLD="${4:-0.7}"
 MULTIFILE_LOCATION=""
 MULTIFILE_START_INDEX=""
 MULTIFILE_STOP_INDEX=""

--- a/src/monolithic/gst/3d_elements/g3dinference/g3dinference.cpp
+++ b/src/monolithic/gst/3d_elements/g3dinference/g3dinference.cpp
@@ -41,7 +41,7 @@ constexpr const char *DEFAULT_DEVICE = "CPU";
 constexpr const char *SUPPORTED_DEVICE_CPU = "CPU";
 constexpr const char *SUPPORTED_DEVICE_GPU = "GPU";
 constexpr const char *DEFAULT_MODEL_TYPE = "pointpillars";
-constexpr float DEFAULT_SCORE_THRESHOLD = 0.0f;
+constexpr float DEFAULT_SCORE_THRESHOLD = 0.7f;
 constexpr size_t POINT_SIZE = 4;
 constexpr size_t DETECTION_WIDTH = 9;
 


### PR DESCRIPTION
### Description

Change g3dinference default threshold from 0.0 to 0.7


### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT. 
- [x] I have not included any company confidential information, trade secret, password or security token. 
- [x] I have performed a self-review of my code.

