### PR TITLE
Solve issue with Docker size checker for forks - soft-skip

### DIFF
--- a/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
+++ b/.github/workflows/dls-build-and-test-deb_pkgs-and-deb_imgs.yaml
@@ -446,6 +446,15 @@ jobs:
             /kB$/ { printf "0"; next }
           ')
 
+          # When the expected-size variable is unavailable (e.g. forks or repos
+          # without the repository variable defined) skip the size gate instead of failing.
+          if [ -z "${EXPECTED_SIZE_MB}" ]; then
+            echo "::notice::Expected image size variable not set (likely a fork). Actual size: ${SIZE_STR} (~${IMAGE_SIZE_MB} MB). Skipping size gate."
+            echo "IMAGE_SIZE_MB=$IMAGE_SIZE_MB" >> $GITHUB_ENV
+            echo "EXPECTED_SIZE_MB=N/A" >> $GITHUB_ENV
+            exit 0
+          fi
+
           echo "Actual image size (docker images SIZE): ${SIZE_STR} (~${IMAGE_SIZE_MB} MB)"
           echo "Expected size: ${EXPECTED_SIZE_MB} MB"
           DIFF=$(( IMAGE_SIZE_MB - EXPECTED_SIZE_MB ))

--- a/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
+++ b/.github/workflows/dls-build-dev-docker-images-and-run-unit.yaml
@@ -229,6 +229,15 @@ jobs:
             /kB$/ { printf "0"; next }
           ')
 
+          # When the expected-size variable is unavailable (e.g. forks or repos
+          # without the repository variable defined) skip the size gate instead of failing.
+          if [ -z "${EXPECTED_SIZE_MB}" ]; then
+            echo "::notice::Expected image size variable not set (likely a fork). Actual size: ${SIZE_STR} (~${IMAGE_SIZE_MB} MB). Skipping size gate."
+            echo "IMAGE_SIZE_MB=$IMAGE_SIZE_MB" >> $GITHUB_ENV
+            echo "EXPECTED_SIZE_MB=N/A" >> $GITHUB_ENV
+            exit 0
+          fi
+
           echo "Actual image size : ${IMAGE_SIZE_MB} MB"
           echo "Expected size: ${EXPECTED_SIZE_MB} MB"
           DIFF=$(( IMAGE_SIZE_MB - EXPECTED_SIZE_MB ))

--- a/.github/workflows/dls-test-optimizer.yaml
+++ b/.github/workflows/dls-test-optimizer.yaml
@@ -338,6 +338,14 @@ jobs:
             /MB$/ { printf "%d", $1; next }
             /kB$/ { printf "0"; next }
           ')
+          # When the expected-size variable is unavailable (e.g. forks or repos
+          # without the repository variable defined) skip the size gate instead of failing.
+          if [ -z "${EXPECTED_SIZE_MB}" ]; then
+            echo "::notice::Expected image size variable not set (likely a fork). Actual size: ${SIZE_STR} (~${IMAGE_SIZE_MB} MB). Skipping size gate."
+            echo "IMAGE_SIZE_MB=$IMAGE_SIZE_MB" >> $GITHUB_ENV
+            echo "EXPECTED_SIZE_MB=N/A" >> $GITHUB_ENV
+            exit 0
+          fi
           echo "Actual image size (docker images SIZE): ${SIZE_STR} (~${IMAGE_SIZE_MB} MB)"
           echo "Expected size: ${EXPECTED_SIZE_MB} MB"
           DIFF=$(( IMAGE_SIZE_MB - EXPECTED_SIZE_MB ))


### PR DESCRIPTION
### Description
When the expected-size variable is unavailable (e.g. forks or repos without the repository variable defined) skip the size gate instead of failing.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

