### PR TITLE
Fix vlm_alerts sample setup instructions in README

### DIFF
--- a/samples/gstreamer/python/vlm_alerts/README.md
+++ b/samples/gstreamer/python/vlm_alerts/README.md
@@ -80,20 +80,17 @@ source .vlm-venv/bin/activate
 ```code
 curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/2/samples/export-requirements.txt
 pip install -r export-requirements.txt
-pip install "transformers>=4.57,<4.58"
-pip install "openvino-tokenizers==2026.2.0.*"
+pip install -r requirements.txt
 ```
 
-> `optimum-intel` currently supports OpenVINO model export only up to
-> `transformers` 4.57.6, while `export-requirements.txt` pins a newer
-> `transformers`. The extra `pip install` step pins a compatible version.
-
-> `openvino-tokenizers` must match the OpenVINO **runtime** shipped with your
-> DL Streamer installation (here `2026.2.0`), which is the one `gvagenai` uses
-> and the one loaded via `PYTHONPATH`. `export-requirements.txt` pins a newer
-> nightly build; if the versions differ, `openvino-tokenizers` is not binary
-> compatible. Adjust the pinned version to match your
-> OpenVINO runtime (check with `python3 -c "import openvino; print(openvino.__version__)"`).
+> `requirements.txt` pins two packages on top of `export-requirements.txt`:
+> `transformers` (`optimum-intel` supports OpenVINO export only up to
+> `transformers` 4.57.6, while `export-requirements.txt` pins a newer one) and
+> `openvino-tokenizers`, which must match the OpenVINO **runtime** shipped with
+> your DL Streamer installation (here `2026.2.0`) — the one `gvagenai` uses and
+> the one loaded via `PYTHONPATH`. If they differ, `openvino-tokenizers` is not
+> binary compatible. Adjust the pinned version to match your OpenVINO runtime
+> (check with `python3 -c "import openvino; print(openvino.__version__)"`).
 
 > A DL Streamer build that includes the `gvagenai` element is required.
 

--- a/samples/gstreamer/python/vlm_alerts/README.md
+++ b/samples/gstreamer/python/vlm_alerts/README.md
@@ -68,15 +68,32 @@ The `gvagenai` element attaches inference results directly as `GstGVATensorMeta`
 1. Create and activate a virtual environment:
 ```code
 cd samples/gstreamer/python/vlm_alerts
-python3 -m venv .vlm-venv
+python3 -m venv --system-site-packages .vlm-venv
 source .vlm-venv/bin/activate
 ```
 
-2. Install dependencies:
+> The `--system-site-packages` flag is required so the virtual environment can
+> use the GStreamer Python bindings (PyGObject / `gi`) provided by the system
+> DL Streamer installation.
+
+1. Install dependencies:
 ```code
 curl -LO https://raw.githubusercontent.com/openvinotoolkit/openvino.genai/refs/heads/releases/2026/2/samples/export-requirements.txt
-pip install -r export-requirements.txt 
+pip install -r export-requirements.txt
+pip install "transformers>=4.57,<4.58"
+pip install "openvino-tokenizers==2026.2.0.*"
 ```
+
+> `optimum-intel` currently supports OpenVINO model export only up to
+> `transformers` 4.57.6, while `export-requirements.txt` pins a newer
+> `transformers`. The extra `pip install` step pins a compatible version.
+
+> `openvino-tokenizers` must match the OpenVINO **runtime** shipped with your
+> DL Streamer installation (here `2026.2.0`), which is the one `gvagenai` uses
+> and the one loaded via `PYTHONPATH`. `export-requirements.txt` pins a newer
+> nightly build; if the versions differ, `openvino-tokenizers` is not binary
+> compatible. Adjust the pinned version to match your
+> OpenVINO runtime (check with `python3 -c "import openvino; print(openvino.__version__)"`).
 
 > A DL Streamer build that includes the `gvagenai` element is required.
 

--- a/samples/gstreamer/python/vlm_alerts/requirements.txt
+++ b/samples/gstreamer/python/vlm_alerts/requirements.txt
@@ -1,0 +1,11 @@
+# Additional pins applied on top of export-requirements.txt (install that first).
+#
+# optimum-intel supports OpenVINO model export only up to transformers 4.57.6,
+# while export-requirements.txt pins a newer transformers.
+transformers>=4.57,<4.58
+#
+# openvino-tokenizers must match the OpenVINO runtime shipped with the DL
+# Streamer installation (here 2026.2.0), which is the one gvagenai uses and the
+# one loaded via PYTHONPATH. Adjust to match your OpenVINO runtime, check with:
+#   python3 -c "import openvino; print(openvino.__version__)"
+openvino-tokenizers==2026.2.0.*


### PR DESCRIPTION
### Description

Fixes the setup instructions for the `vlm_alerts` GStreamer Python sample
(`samples/gstreamer/python/vlm_alerts/README.md`). Three independent blockers were addressed:

1. **PyGObject / `gi` not found in the virtual environment.** The venv was
   created without access to system site-packages, so `import gi` resolved to
   the incomplete `gi` namespace package injected via `PYTHONPATH`
   (`/opt/intel/dlstreamer/.../gi`, `.../python/gi`, which contain only
   `overrides/`) instead of the real PyGObject provided by the DL Streamer
   installation. This failed with
   `AttributeError: module 'gi' has no attribute 'require_version'`. Fixed by
   creating the venv with `--system-site-packages`.

2. **`transformers` too new for OpenVINO export.** `export-requirements.txt`
   pins `transformers==5.0.0`, but `optimum-intel` supports export only up to
   `transformers` 4.57.6. This surfaced as
   `ValueError: The current version of Transformers does not allow for the export of the model`
   for native models, and as
   `RuntimeError: Tensor.item() cannot be called on meta tensors` for models
   loaded with `--trust-remote-code` (transformers 5 initializes the model on
   the `meta` device). Fixed by pinning `transformers>=4.57,<4.58`.

3. **`openvino-tokenizers` binary-incompatible with the platform OpenVINO
   runtime.** `export-requirements.txt` pins a newer nightly
   (`openvino-tokenizers 2026.2.1`), while the OpenVINO runtime shipped with DL
   Streamer and used by `gvagenai` is `2026.2.0` (loaded via `PYTHONPATH`). The
   mismatch caused `openvino-tokenizers` to fail loading, so the tokenizer was
   silently skipped during export (no `openvino_tokenizer.xml`), and the
   pipeline failed at runtime with `Tokenizer::encode is not available`. Fixed
   by pinning `openvino-tokenizers` to match the platform OpenVINO runtime.

All changes are documentation-only (README setup steps and explanatory notes);
no source code was modified.

### Checklist:

- [x] I agree to use the MIT license for my code changes.
- [x] I have not introduced any 3rd party components incompatible with MIT.
- [x] I have not included any company confidential information, trade secret, password or security token.
- [x] I have performed a self-review of my code.
