### PR TITLE
Document raw tensor metadata (GstAnalyticsTensorMtd)

### DIFF
--- a/docs/user-guide/dev_guide/metadata.md
+++ b/docs/user-guide/dev_guide/metadata.md
@@ -25,7 +25,7 @@ Key types:
 | `GstAnalyticsKeypointMtd` | Single keypoint |
 | `GstAnalyticsGroupMtd` | Ordered group of metadata |
 | `GstAnalyticsSegmentationMtd` | Semantic segmentation (class-index mask) |
-| `GstAnalyticsTensorMtd` | Raw tensor payload (used for instance-segmentation soft masks) |
+| `GstAnalyticsTensorMtd` | Raw tensor payload — generic `gvainference` output tensors and instance-segmentation soft masks |
 | `GstAnalyticsKeypointDescriptor` | Static keypoint layout registry — DL Streamer extension |
 | `GstAnalyticsZoneMtd` | Zone presence (zone ID) — DL Streamer extension |
 | `GstAnalyticsTripwireMtd` | Tripwire crossing (tripwire ID, direction) — DL Streamer extension |
@@ -98,10 +98,10 @@ For reference documentation of the legacy API, see
 |---|---|---|---|---|
 | `gvadetect` (full-frame) | Object detection on full frame | GstBuffer | ODMtd, ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsTensorMtd | ROI + GstStructure params |
 | `gvadetect` (roi-list) | Object detection per ROI | GstBuffer + ROI + ODMtd | ODMtd, ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsTensorMtd | ROI (with parent_id) + GstStructure params |
-| `gvaclassify` (roi-list) | Object classification per ROI | GstBuffer + ROI + ODMtd | ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsSegmentationMtd | extended ROI params |
-| `gvaclassify` (full-frame) | Full-frame classification | GstBuffer | ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsSegmentationMtd | GstGVATensorMeta |
-| `gvainference` (full-frame) | Generic full-frame inference | GstBuffer | — | GstGVATensorMeta |
-| `gvainference` (roi-list) | Generic inference per ROI | GstBuffer + ROI + ODMtd | — | extended ROI params |
+| `gvaclassify` (roi-list) | Object classification per ROI | GstBuffer + ROI + ODMtd | ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsSegmentationMtd, GstAnalyticsTensorMtd | extended ROI params |
+| `gvaclassify` (full-frame) | Full-frame classification | GstBuffer | ClsMtd, GstAnalyticsGroupMtd, GstAnalyticsKeypointMtd, GstAnalyticsSegmentationMtd, GstAnalyticsTensorMtd | GstGVATensorMeta |
+| `gvainference` (full-frame) | Generic full-frame inference | GstBuffer | GstAnalyticsTensorMtd | GstGVATensorMeta |
+| `gvainference` (roi-list) | Generic inference per ROI | GstBuffer + ROI + ODMtd | GstAnalyticsTensorMtd | extended ROI params |
 | `gvatrack` | Object tracking | GstBuffer + ROI + ODMtd | TrackingMtd | ROI + object_id param |
 | `gvaanalytics` | Zone and tripwire analytics | GstBuffer + ODMtd + TrackingMtd | ZoneMtd, TripwireMtd, WatermarkDrawMeta, WatermarkCircleMeta | — |
 | `gvametaconvert` | Metadata → JSON | GstBuffer + ROI + ODMtd + ClsMtd + GstAnalyticsGroupMtd + GstAnalyticsKeypointMtd + TrackingMtd + GstAnalyticsSegmentationMtd + GstAnalyticsTensorMtd + ZoneMtd + TripwireMtd + 3DODMtd + LidarMeta + GstRadarProcessMeta + GstAnalyticsBatchMeta + GstGVATensorMeta | — | GstGVAJSONMeta |

--- a/docs/user-guide/dev_guide/metadata_analytics.md
+++ b/docs/user-guide/dev_guide/metadata_analytics.md
@@ -18,7 +18,7 @@ upstream
 | `GstAnalyticsTrackingMtd` | Object tracking (ID, timestamps) |
 | `GstAnalyticsKeypointMtd` | Single keypoint (x, y, z, confidence, visibility) |
 | `GstAnalyticsSegmentationMtd` | Semantic segmentation (class-index mask) |
-| `GstAnalyticsTensorMtd` | Raw tensor payload (used for instance-segmentation soft masks) |
+| `GstAnalyticsTensorMtd` | Raw tensor payload — generic `gvainference` output tensors and instance-segmentation soft masks |
 | `GstAnalyticsGroupMtd` | Ordered group of metadata |
 | `GstAnalyticsKeypointDescriptor` | Static keypoint layout registry (DL Streamer extension) |
 | `GstAnalyticsZoneMtd` | Zone presence — carries the zone ID string (DL Streamer extension) |
@@ -291,6 +291,41 @@ than a frame-level segmentation image, which lets `gvawatermark` blend it
 smoothly over each ROI. The `model_name/instance_segmentation` semantic tag is
 what distinguishes an instance mask from any other raw tensor metadata.
 
+### Raw tensors (generic inference output)
+
+Model outputs that are **not** interpreted into a higher-level metadata type
+(classification, detection, keypoints, segmentation) are stored verbatim as a
+`GstAnalyticsTensorMtd`. The main producer is `gvainference`, which attaches its
+raw output tensor(s) for any model (full-frame or per-ROI).
+
+At the frame level (`gvainference` with `inference-region=full-frame`) the
+tensor has no parent `ODMtd`:
+
+```
+gvainference (inference-region=full-frame, model=resnet-50)
+  │
+  └─ GstAnalyticsRelationMeta
+       └─ TensorMtd (FP32 [1, 1000], row-major,
+                     semantic_tag="resnet-50")
+```
+
+Per-ROI (`inference-region=roi-list`, or a second-stage model over detections)
+the tensor is attached to its parent `ODMtd` via a `CONTAIN` relation:
+
+```
+gvadetect
+  └─ ODMtd (label="person", ..., semantic_tag="yolov26n")
+
+gvainference (inference-region=roi-list, model=reid-model)
+  └─ ODMtd ─CONTAIN→ TensorMtd (FP32 [1, 256], row-major,
+                                semantic_tag="reid-model")
+```
+
+The payload is copied verbatim: `precision`, `dims`, `dims_order` and the raw
+`data` come straight from the model output layer. Instance-segmentation soft
+masks (see above) are a special case of raw tensor, distinguished only by the
+`/instance_segmentation` suffix appended to their semantic tag.
+
 ### 3D object detection (LiDAR / radar)
 
 3D detectors produce oriented boxes in a sensor/world coordinate frame rather
@@ -346,6 +381,7 @@ DL Streamer uses semantic tags to:
 | `ClsMtd` | model name | `"densenet-121"` |
 | `GroupMtd` (keypoints) | `model_name/keypoint_format` | `"hrnet/body-pose/coco-17"` |
 | `SegmentationMtd` (semantic segmentation) | model name | `"deeplabv3"` |
+| `TensorMtd` (raw tensor) | model name | `"resnet-50"` |
 | `TensorMtd` (instance segmentation) | `model_name/instance_segmentation` | `"yolov8-seg/instance_segmentation"` |
 
 The semantic tag enables downstream elements to distinguish metadata


### PR DESCRIPTION
Describe generic raw tensors carried as GstAnalyticsTensorMtd: gvainference frame-level and per-ROI flow examples, the DL Streamer field usage (precision, dims, dims_order, data, semantic_tag), and the /instance_segmentation suffix that distinguishes instance masks. Update the type tables and gvainference rows in the element I/O summary.


### Description

Please include a summary of the changes and the related issue. List any dependencies that are required for this change.

Fixes # (issue)

### Any Newly Introduced Dependencies

Please describe any newly introduced 3rd party dependencies in this change. List their name, license information and how they are used in the project.

### How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

### Checklist:

- [ ] I agree to use the MIT license for my code changes.
- [ ] I have not introduced any 3rd party components incompatible with MIT. 
- [ ] I have not included any company confidential information, trade secret, password or security token. 
- [ ] I have performed a self-review of my code.

